### PR TITLE
Use virtual Java packages on Red Hat and set java_bin

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/default.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/default.erb
@@ -2,8 +2,8 @@
 # Init settings for <%= EZBake::Config[:project] %>
 ###########################################
 
-# Location of your Java binary (version 8)
-JAVA_BIN="/usr/bin/java"
+# Location of your Java binary
+#JAVA_BIN=""
 
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
 JAVA_ARGS="<%= EZBake::Config[:java_args] %>"

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/debian/ezbake.init.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/debian/ezbake.init.erb
@@ -22,6 +22,8 @@
 #set default privileges to -rw-r-----
 umask 027
 
+JAVA_BIN=<%= EZBake::Config[:java_bin] %>
+
 # You should only need to edit the default/<%= EZBake::Config[:project] %> file and not
 #   this init script directly
 if [ -r "/etc/default/<%= EZBake::Config[:project] %>" ] ; then

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/debian/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/debian/ezbake.service.erb
@@ -20,6 +20,7 @@ Wants=<%= EZBake::Config[:start_after].map {|dep| "#{dep}.service" }.join(" ") %
 
 [Service]
 Type=forking
+Environment=JAVA_BIN="<%= EZBake::Config[:java_bin] %>"
 EnvironmentFile=/etc/default/<%= EZBake::Config[:project] %>
 User=<%= EZBake::Config[:user] %>
 TimeoutStartSec=<%= EZBake::Config[:start_timeout] %>

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -14,6 +14,7 @@ options.old_el = 0
 options.old_sles = 0
 options.sles = 0
 options.java = 'java-1.8.0-openjdk-headless'
+options.java_bin = '/usr/bin/java'
 options.release = 1
 options.platform_version = 0
 options.is_pe = false
@@ -189,25 +190,16 @@ if options.output_type == 'rpm'
     options.systemd_el = 1
   elsif options.operating_system == :el && options.os_version >= 7 # systemd el
     if ! options.is_pe
-      fpm_opts << "--depends tzdata-java"
-      options.java =
-        case options.platform_version
-        when 8
-          # rpm on Redhat 7 may not support OR dependencies
-          if options.os_version == 7
-            'java-11-openjdk-headless'
-          elsif options.os_version == 8
-            '(java-17-openjdk-headless or java-11-openjdk-headless)'
-          elsif options.os_version >= 9
-            'java-17-openjdk-headless'
-          else
-            fail "Unrecognized el os version #{options.os_version}"
-          end
-        when 7
-          'java-11-openjdk-headless'
-        else
-          fail "Unknown Puppet Platform Version #{options.platform_version}"
-        end
+      # rpm on Redhat 7 may not support OR dependencies
+      if options.os_version == 7
+        options.java = 'jre-11-headless'
+        options.java_bin = '/usr/lib/jvm/jre-11/bin/java'
+      elsif options.os_version >= 8
+        options.java = 'jre-17-headless'
+        options.java_bin = '/usr/lib/jvm/jre-17/bin/java'
+      else
+        fail "Unrecognized el os version #{options.os_version}"
+      end
     end
 
     options.systemd = 1

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.service.erb
@@ -20,6 +20,7 @@ Wants=<%= EZBake::Config[:start_after].map {|dep| "#{dep}.service" }.join(" ") %
 
 [Service]
 Type=forking
+Environment=JAVA_BIN="<%= EZBake::Config[:java_bin] %>"
 EnvironmentFile=/etc/sysconfig/<%= EZBake::Config[:project] %>
 User=<%= EZBake::Config[:user] %>
 TimeoutStartSec=<%= EZBake::Config[:start_timeout] %>


### PR DESCRIPTION
This is a copy of the PR to puppetlabs ezbake at https://github.com/puppetlabs/ezbake/pull/627. Additionally, this removes some more logic around determining Java version vs. Puppet Platform version, since we are only using this for OpenVox 7 and 8 and they should both use the same Java versions now.

Original work by @ekohl 