### PR TITLE
Remove platform version complexity for Java version

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '8', '11' ]
+        java: [ '11, '17' ]
     env:
       LEIN_HOME: local
 

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -189,24 +189,13 @@ if options.output_type == 'rpm'
     options.systemd_el = 1
   elsif options.operating_system == :el && options.os_version >= 7 # systemd el
     if ! options.is_pe
-      fpm_opts << "--depends tzdata-java"
       options.java =
-        case options.platform_version
-        when 8
-          # rpm on Redhat 7 may not support OR dependencies
-          if options.os_version == 7
-            'java-11-openjdk-headless'
-          elsif options.os_version == 8
-            '(java-17-openjdk-headless or java-11-openjdk-headless)'
-          elsif options.os_version >= 9
-            'java-17-openjdk-headless'
-          else
-            fail "Unrecognized el os version #{options.os_version}"
-          end
-        when 7
+        if options.os_version == 7
           'java-11-openjdk-headless'
+        elsif options.os_version >= 8
+          'java-17-openjdk-headless'
         else
-          fail "Unknown Puppet Platform Version #{options.platform_version}"
+          fail "Unrecognized el os version #{options.os_version}"
         end
     end
 
@@ -223,19 +212,7 @@ if options.output_type == 'rpm'
     options.systemd_sles = 1
     options.sles = 1
     if ! options.is_pe
-      options.java =
-        case options.platform_version
-        when 8
-          'java-11-openjdk-headless'
-        when 7
-          if options.os_version > 12
-            'java-11-openjdk-headless'
-          else
-            'java-1_8_0-openjdk-headless'
-          end
-        else
-          fail "Unknown Puppet Platform Version #{options.platform_version}"
-        end
+      options.java = 'java-11-openjdk-headless'
     end
   elsif options.operating_system == :sles #old sles
     options.sysvinit = 1

--- a/test/unit/puppetlabs/ezbake/core_test.clj
+++ b/test/unit/puppetlabs/ezbake/core_test.clj
@@ -40,6 +40,7 @@
                     :is-pe-build "false"
                     :reload-timeout "'120'"
                     :bootstrap-source "'bootstrap-cfg'"
+                    :package-name "'dummy'"
                     :debian-interested-install-triggers ()
                     :group "'dummy'"
                     :java-args "'-Xmx192m'"


### PR DESCRIPTION
OpenVox only supports platform 7 and 8, and we don't really need to worry about ancient el8 being weird. We build OpenVox with Java 11, so make this the base version, and ideally use 17 when available.