### PR TITLE
Revert "(PE-36861) Add a needrestart conf file for debian packages"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This changelog adheres to [Keep a CHANGELOG](http://keepachangelog.com/).
 * Add Debian 12 bookworm as a FOSS build target
 * Use systemd's PrivateTmp feature for improved security
 * Test ezbake on Java 11, 17 and 21
+* Remove /etc/needrestart/conf.d/ config for deb packages to restart services on Java Updates
 
 ## [2.6.1]
 * Fix the ability to add a resources directory to a project with :include-dir by copying the resources to the staging directory directly.

--- a/resources/puppetlabs/lein-ezbake/staging-templates/project_data.yaml.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/project_data.yaml.mustache
@@ -33,8 +33,6 @@ templates:
     target: ext/{{{project}}}.logrotate.conf
   - source: ext/ezbake.tmpfiles.conf.erb
     target: ext/{{{project}}}.tmpfiles.conf
-  - source: ext/ezbake.needrestart.conf.erb
-    target: ext/{{{project}}}.needrestart.conf
   - ext/redhat/preinst.erb
   - ext/redhat/postinst.erb
   - ext/redhat/prerm.erb

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake.needrestart.conf.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake.needrestart.conf.erb
@@ -1,1 +1,0 @@
-push @{$nrconf{blacklist_rc}}, qr(^<%= EZBake::Config[:project] -%>)

--- a/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
@@ -34,7 +34,6 @@ dest_apps_dir="${DESTDIR}${app_prefix}"
 app_data=${app_data:=/opt/puppetlabs/server/data/${real_name}}
 app_logdir=${app_logdir:=/var/log/puppetlabs/${real_name}}
 system_config_dir=${system_config_dir:=${app_prefix}/config}
-needrestart_confdir=${needrestart_dir:=/etc/needrestart/conf.d}
 
 
 ##################
@@ -250,8 +249,6 @@ function task_systemd_deb {
     install -m 0644 ext/debian/<%= EZBake::Config[:project] %>.service_file "${DESTDIR}${unitdir_debian}/<%= EZBake::Config[:project] %>.service"
     install -d -m 0755 "${DESTDIR}${tmpfilesdir}"
     install -m 0644 ext/<%= EZBake::Config[:project] %>.tmpfiles.conf "${DESTDIR}${tmpfilesdir}/<%= EZBake::Config[:project] %>.conf"
-    install -d -m 0755 "${DESTDIR}${needrestart_confdir}"
-    install -m 0644 ext/<%= EZBake::Config[:project] %>.needrestart.conf "${DESTDIR}${needrestart_confdir}/<%= EZBake::Config[:project] %>.conf"
 }
 
 function task_service_account {


### PR DESCRIPTION
This reverts commit e43660e2363c45d7a35d4ef36246f8866764f5d9.

e43660e2363c45d7a35d4ef36246f8866764f5d9 added a denylist for needrestart to ignore openvoxdb/openvoxserver. Both services write files into /tmp/, which triggered service restarts, that were not required.

Since
https://github.com/puppetlabs/ezbake/pull/623/commits/bf1a75d757b0f5e6ed7db1ddde7dc13e4984649c, both services use the PrivateTmp feature from systemd, that makes the denylist obsolete.

This now ensures that needsrestart will restart openvoxdb/openvoxserver on Java updates. That will fix
https://github.com/puppetlabs/puppetserver/issues/2900.

Please add all notable changes to the "Unreleased" section of the CHANGELOG.