### PR TITLE
Restore rendering of CLI apps

### DIFF
--- a/resources/puppetlabs/lein-ezbake/staging-templates/project_data.yaml.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/project_data.yaml.mustache
@@ -39,6 +39,7 @@ templates:
   - ext/debian/postinst.erb
   - ext/config/user/conf.d/*.erb
   - ext/bin/*.erb
+  - ext/cli/*.erb
   - ext/default.erb
   - ext/ezbake-functions.sh.erb
   - install.sh.erb


### PR DESCRIPTION
This fixes a regression introduced in
https://github.com/OpenVoxProject/ezbake/pull/5 / b2de7c7a2e7704491a08665a9f53ded8009aa109

openvox-server has some ERB templates:
https://github.com/OpenVoxProject/openvox-server/tree/main/resources/ext/cli and since above change, they aren't rendered anymore. The templates are still required and builds fail.

Was required to get https://github.com/OpenVoxProject/openvox-server/pull/35 to build packages