### PR TITLE
packaging: Switch from Perforce to OpenVoxProject releases

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/Gemfile
+++ b/resources/puppetlabs/lein-ezbake/template/global/Gemfile
@@ -1,14 +1,5 @@
-source ENV['GEM_SOURCE'] || 'https://artifactory.delivery.puppetlabs.net/artifactory/api/gems/rubygems/'
+source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
-def location_for(place, fake_version = nil)
-  if place =~ /^(git[:@][^#]*)#(.*)/
-    [fake_version, { :git => $1, :branch => $2, :require => false }].compact
-  elsif place =~ /^file:\/\/(.*)/
-    ['>= 0', { :path => File.expand_path($1), :require => false }]
-  else
-    [place, { :require => false }]
-  end
-end
-
-gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99')
+# 1.0.0 is the first OpenVoxProject release
+gem 'packaging', '~> 1.0', github: 'OpenVoxProject/packaging'
 gem 'fpm'


### PR DESCRIPTION
The Gemfile is a template. For every ezbake based build, the Gemfile is copied into the build dir. Aftwards the gems are installed. the packaging gem is used to publish packages, update repos and render different templates, e.g. the systemd unit files for openvox-server and openvox-db.

As far as I know, the erb template rendering is the only feature from packaging that we use. I didn't want to deal with a new gem name yet, the packaging rubygems namespace is already owned by Perforce: https://rubygems.org/gems/packaging

I assume in the long term we will get rid of packaging, so I didn't bother with renaming the gem. Because of that, we cannot publish it to rubygems.org right. Because of that the Gemfile now uses `github:` to fetch the release from there.