### PR TITLE
deb: Dont include /usr in package

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -134,7 +134,7 @@ if options.sources.empty?
                     when :amazon, :fedora, :sles, :el, :redhatfips
                       ['etc', 'opt', 'usr', 'var']
                     when :debian, :ubuntu
-                      ['etc', 'lib', 'opt', 'usr', 'var']
+                      ['etc', 'lib', 'opt', 'var']
                     else
                       fail "I don't know what your default sources should be, pass it on the command line!"
                     end


### PR DESCRIPTION
The `/usr` directory contains only two files:

```
/usr
/usr/lib
/usr/lib/tmpfiles.d
/usr/lib/tmpfiles.d/puppetserver.conf
/usr/share
/usr/share/doc
/usr/share/doc/openvox-server
/usr/share/doc/openvox-server/changelog.gz
```

Since https://github.com/OpenVoxProject/ezbake/pull/5, we don't package /usr/lib/tmpfiles.d/puppetserver.conf anymore. And the changelog.gz is autogenerated by fpm afterwards. That means that in our packaging directory, there is no `/usr`. If we force fpm to package it, it will raise an error.

This change was tested in https://github.com/OpenVoxProject/openvox-server