### PR TITLE
introduce java_bin ezbake option

### DIFF
--- a/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
@@ -73,6 +73,7 @@ module EZBake
       :main_namespace => {{{main-namespace}}},
       :java_args      => {{{java-args}}},
       :java_args_cli  => {{{java-args-cli}}},
+      :java_bin       => {{{java-bin}}},
       :tk_args        => {{{tk-args}}},
       :start_before   => {{{start-before}}},
       :start_after    => {{{start-after}}},

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -89,6 +89,7 @@
    (schema/optional-key :main-namespace) schema/Str
    (schema/optional-key :java-args) schema/Str
    (schema/optional-key :java-args-cli) schema/Str
+   (schema/optional-key :java-bin) schema/Str
    (schema/optional-key :tk-args) schema/Str
    (schema/optional-key :redhat-postinst-install-triggers) RPMTriggers
    (schema/optional-key :redhat-postinst-upgrade-triggers) RPMTriggers
@@ -661,6 +662,8 @@ Additional uberjar dependencies:
      :java-args                          (local->ruby :java-args
                                                       "-Xmx192m")
      :java-args-cli                      (local->ruby :java-args-cli "")
+     :java-bin                           (local->ruby :java-bin
+                                                      "/usr/bin/java")
      :tk-args                            (local->ruby :tk-args "")
      :bootstrap-source                   (-> (get-local :bootstrap-source :bootstrap-cfg)
                                              name as-ruby-literal)

--- a/test/unit/puppetlabs/ezbake/core_test.clj
+++ b/test/unit/puppetlabs/ezbake/core_test.clj
@@ -71,6 +71,7 @@
                     :project "'dummy'"
                     :debian-postinst-install "[]"
                     :java-args-cli "''"
+                    :java-bin "'/usr/bin/java'"
                     :cli-defaults-file "'ext/cli_defaults/cli-defaults.sh'"
                     :debian-install "[]"
                     :redhat-postinst-install-triggers []


### PR DESCRIPTION
In https://github.com/OpenVoxProject/ezbake/pull/2/commits/6b3ad939736bb8d0f0a22a715f398a49a678a8d3 we introduced a new configuration option for `java_bin`. To get this working, we need to add it to ezbake itself. Otherwise the variable won't exist and we cannot use it in templates:

```
ExecStart= $JAVA_ARGS $LOG_APPENDER \
  '-XX:OnOutOfMemoryError=kill -9 %p' -XX:+CrashOnOutOfMemoryError \
  -XX:ErrorFile="$LOGS_DIRECTORY/puppetserver_err_pid%p.log" \
  -cp "$INSTALL_DIR/puppet-server-release.jar" \
  clojure.main \
  -m puppetlabs.trapperkeeper.main \
  --config "$CONFIG" \
  --bootstrap-config "$BOOTSTRAP_CONFIG" \
  $TK_ARGS
```

(see the whitespace after `ExecStart=` where the java path should be.