### PR TITLE
fpm.rb: Patch java_bin in defaults file & unit file

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/default.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/default.erb
@@ -2,6 +2,9 @@
 # Init settings for <%= EZBake::Config[:project] %>
 ###########################################
 
+# used by openvox-server CLI apps, not by the systemd unit
+JAVA_BIN="<%= EZBake::Config[:java_bin] %>"
+
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
 JAVA_ARGS="<%= EZBake::Config[:java_args] %>"
 

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -204,12 +204,12 @@ if options.output_type == 'rpm'
   end
 
   # patch the systemd unit file to have the correct JAVA_BIN
-  paths = [
-    "#{options.chdir}/usr/lib/systemd/system/puppet*.service",
-    "#{options.chdir}/lib/systemd/system/puppet*.service",
+  systemd_paths = [
+    "#{options.chdir}/usr/lib/systemd/system/puppet*.service", # EL family
+    "#{options.chdir}/lib/systemd/system/puppet*.service",     # Debian family
   ]
   searchstring = '/usr/bin/java'
-  Dir.glob(paths).each do |file_path|
+  Dir.glob(systemd_paths).each do |file_path|
     lines = File.readlines(file_path).map do |line|
       line.include?(searchstring) ? line.sub(searchstring, options.java_bin) : line
     end

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -210,10 +210,9 @@ if options.output_type == 'rpm'
   ]
   searchstring = '/usr/bin/java'
   Dir.glob(systemd_paths).each do |file_path|
-    lines = File.readlines(file_path).map do |line|
-      line.include?(searchstring) ? line.sub(searchstring, options.java_bin) : line
-    end
-    File.write(file_path, lines.join)
+    unit = File.read(file_path)
+    new_content = unit.gsub(/(ExecStart=)(\S+)/) { "#{Regexp.last_match(1)}#{options.java_bin}" }
+    File.write(file_path, new_content)
     puts "patched JAVA_BIN in #{file_path} from #{searchstring} to #{options.java_bin}"
   end
 

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -307,21 +307,40 @@ elsif options.output_type == 'deb'
   end
 end
 
+# because this hacky hack is hacky, we only run it if the desired java version is different compared to our defaults
+# we want to prevent accidents here
 if options.java_bin != EZBake::Config[:java_bin]
-  # patch the environment and systemd unit files so it has the correct JAVA_BIN
-  paths = [
+  # also why don't we use `File.write(path, content.gsub(EZBake::Config[:java_bin], options.java_bin))`
+  # ezbake renders the environment and systemd files once.
+  # Afterwards we iterate on all OSes we want to create packages for.
+  # fpm.rb is executed for each OS. that means it's not a clean build environment,
+  # we iterate below patch multiple times on the same file
+
+  # patch the sysconfig file so it has the correct JAVA_BIN
+  default_paths = [
     "#{options.chdir}/etc/sysconfig/puppet*", # EL family
     "#{options.chdir}/etc/default/puppet*",   # Debian family
+  ]
+  target = "JAVA_BIN=#{options.java_bin}"
+  Dir.glob(default_paths).each do |file_path|
+    lines = File.readlines(file_path).map do |line|
+      line.start_with?('JAVA_BIN=') ? target : line
+    end
+    File.write(file_path, lines.join)
+    if options.debug
+      puts "patched JAVA_BIN in #{file_path} to #{options.java_bin}"
+    end
+  end
+
+  # patch the systemd unit file to have the correct JAVA_BIN
+  systemd_paths = [
     "#{options.chdir}/usr/lib/systemd/system/puppet*.service", # EL family
     "#{options.chdir}/lib/systemd/system/puppet*.service",     # Debian family
   ]
-  # we are using globbing here to find all related files,
-  # but also try to limit this down as much as possible.
-  # This whole hack is quite hacky and we want to avoid side effects at all costs
-  # ezbake is used for openvoxdb and openvox-server projects, so we need to match both names
-  Dir.glob(paths).each do |path|
-    content = File.read(path)
-    File.write(path, content.gsub(EZBake::Config[:java_bin], options.java_bin))
+  Dir.glob(systemd_paths).each do |file_path|
+    unit = File.read(file_path)
+    new_content = unit.gsub(/(ExecStart=)(\S+)/) { "#{Regexp.last_match(1)}#{options.java_bin}" }
+    File.write(file_path, new_content)
     if options.debug
       puts "patched JAVA_BIN in #{file_path} to #{options.java_bin}"
     end


### PR DESCRIPTION
This ensures that EL packages have the correct java path in the systemd unit. And all packages have JAVA_BIN variable in their defaults file. This is probably required for the different CLI apps.

There's a systemd limitation that prevents us from doing something like ExecStart=$VAR.. The first argument for ExecStart= cannot be a variable.

From https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Command%20lines

> The command to execute may contain spaces, but control characters are not allowed.

What they mean is: Control characters like $ are allowed but won't be interpolated.

---

This PR also contains https://github.com/OpenVoxProject/ezbake/pull/29