### PR TITLE
unit file: fix uninitialized LOG_APPENDER variable

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/debian/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/debian/ezbake.service.erb
@@ -50,7 +50,7 @@ ExecStartPre=<%= action %>
 <% end -%>
 <% end -%>
 
-ExecStart=<%= EZBake::Config[:java_bin] %> $JAVA_ARGS $LOG_APPENDER \
+ExecStart=<%= EZBake::Config[:java_bin] %> $JAVA_ARGS -Dlogappender=F1 \
   '-XX:OnOutOfMemoryError=kill -9 %p' -XX:+CrashOnOutOfMemoryError \
   -XX:ErrorFile="${LOGS_DIRECTORY}/<%= EZBake::Config[:real_name] %>_err_pid%p.log" \
   -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" \

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.service.erb
@@ -50,7 +50,7 @@ ExecStartPre=<%= action %>
 <% end -%>
 <% end -%>
 
-ExecStart=<%= EZBake::Config[:java_bin] %> $JAVA_ARGS $LOG_APPENDER \
+ExecStart=<%= EZBake::Config[:java_bin] %> $JAVA_ARGS -Dlogappender=F1 \
   '-XX:OnOutOfMemoryError=kill -9 %p' -XX:+CrashOnOutOfMemoryError \
   -XX:ErrorFile="${LOGS_DIRECTORY}/<%= EZBake::Config[:real_name] %>_err_pid%p.log" \
   -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" \


### PR DESCRIPTION
This was initially set in /opt/puppetlabs/server/apps/puppetserver/cli/apps/foreground and went missing during https://github.com/OpenVoxProject/ezbake/commit/b2de7c7a2e7704491a08665a9f53ded8009aa109

Thix fixes a regression.

---

This also contains https://github.com/OpenVoxProject/ezbake/pull/28