### PR TITLE
Patch java_bin if overridden

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/default.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/default.erb
@@ -2,6 +2,9 @@
 # Init settings for <%= EZBake::Config[:project] %>
 ###########################################
 
+# used by openvox-server CLI apps, not by the systemd unit
+JAVA_BIN="<%= EZBake::Config[:java_bin] %>"
+
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
 JAVA_ARGS="<%= EZBake::Config[:java_args] %>"
 

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -5,12 +5,36 @@ require 'optparse'
 require 'ostruct'
 
 options = OpenStruct.new
+
+# ezbake.rb is rendered from
+# resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
+#
+# inside the build container, fpm.rb is at:
+# /code/target/staging/puppetserver-8.9.0/ext/fpm.rb
+# ezbake:
+# /code/target/staging/ezbake.rb
+#
+# we do this hula hoop jump because in our build process the ezbake.rb exists
+# We also distribute a .tar.gz. This contains the compiled jar + fpm.rb.
+# fpm.rb is executed while we build the packages. This is the same process as
+# compiling the jar and rendering ezbake from
+# resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
+# people that try to build their own package based on our tar, like FreeBSD, don't have the ezbake.rb
+#
+# patches welcome to move ezbake.rb into the tar *or* get rid of ezbake
+begin
+  require_relative '../../ezbake'
+rescue LoadError
+  options.java_bin = '/usr/bin/java'
+else
+  options.java_bin = EZBake::Config[:java_bin]
+end
+
 # settin' some defaults
 options.systemd_el = 0
 options.systemd_sles = 0
 options.sles = 0
 options.java = 'java-1.8.0-openjdk-headless'
-options.java_bin = '/usr/bin/java'
 options.release = 1
 options.platform_version = 0
 options.replaces = {}


### PR DESCRIPTION
Credits to @bastelfreak for doing a lot of the research in this and writing up large parts of the proof of concept. This takes the lessons from https://github.com/OpenVoxProject/ezbake/pull/27 and makes it a bit cleaner by restoring the whole file after running fpm.

This first updates the code to load `java_bin` from ezbake, if possible.

In https://github.com/OpenVoxProject/ezbake/commit/9768a77de95ff19f66f4b328fc60efe69f5f3a6b the java binary was overridden, but this didn't have a point because it's not available when the files are rendered. They only have access to the ezbake config.

This takes an approach of patching the files after the fact. It writes out backup files that are restored after. That is to deal with the fact that our build process isn't clean and is reused between multiple builds.

Fixes: https://github.com/OpenVoxProject/ezbake/commit/9768a77de95ff19f66f4b328fc60efe69f5f3a6b ("Use virtual Java packages on Red Hat and set java_bin")