### PR TITLE
Ensure the RuntimeDirectory exists

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/debian/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/debian/ezbake.service.erb
@@ -21,6 +21,7 @@ Wants=<%= EZBake::Config[:start_after].map {|dep| "#{dep}.service" }.join(" ") %
 [Service]
 Type=exec
 LogsDirectory=puppetlabs/<%= EZBake::Config[:real_name] %>
+RuntimeDirectory=puppetlabs/<%= EZBake::Config[:real_name] %>
 EnvironmentFile=/etc/default/<%= EZBake::Config[:project] %>
 User=<%= EZBake::Config[:user] %>
 TimeoutStartSec=<%= EZBake::Config[:start_timeout] %>

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.service.erb
@@ -21,6 +21,7 @@ Wants=<%= EZBake::Config[:start_after].map {|dep| "#{dep}.service" }.join(" ") %
 [Service]
 Type=exec
 LogsDirectory=puppetlabs/<%= EZBake::Config[:real_name] %>
+RuntimeDirectory=puppetlabs/<%= EZBake::Config[:real_name] %>
 EnvironmentFile=/etc/sysconfig/<%= EZBake::Config[:project] %>
 User=<%= EZBake::Config[:user] %>
 TimeoutStartSec=<%= EZBake::Config[:start_timeout] %>


### PR DESCRIPTION
Prior to b2de7c7a2e7704491a08665a9f53ded8009aa109 a tmpfiles config file was created to ensure the run directory exists. It was dropped, but causes the server to refuse to start up.

This instead makes systemd responsible for creating it when the service starts.

Fixes: b2de7c7a2e7704491a08665a9f53ded8009aa109 ("Drop service wrappers")