### PR TITLE
Restore foreground.erb & cli_defaults packaging

### DIFF
--- a/resources/puppetlabs/lein-ezbake/staging-templates/project_data.yaml.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/project_data.yaml.mustache
@@ -40,6 +40,7 @@ templates:
   - ext/config/user/conf.d/*.erb
   - ext/bin/*.erb
   - ext/cli/*.erb
+  - ext/cli_defaults/*.erb
   - ext/default.erb
   - install.sh.erb
   - controller.sh.erb

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/foreground.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/foreground.erb
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+restartfile="/opt/puppetlabs/server/data/<%= EZBake::Config[:real_name] %>/restartcounter"
+cli_defaults=${INSTALL_DIR}/cli/cli-defaults.sh
+
+if [ ! -e "${INSTALL_DIR}/ezbake-functions.sh" ]; then
+    echo "Unable to find ${INSTALL_DIR}/ezbake-functions.sh script, failing start." 1>&2
+    exit 1
+fi
+
+. "${INSTALL_DIR}/ezbake-functions.sh"
+
+init_restart_file "$restartfile" || exit $?
+
+if !(echo "${@}" | grep -e "--debug" -q)
+then
+    LOG_APPENDER="-Dlogappender=STDOUT"
+fi
+
+CLASSPATH="${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>"
+
+if [ -e "$cli_defaults" ]; then
+  . $cli_defaults
+  if [ $? -ne 0 ]; then
+    echo "Unable to initialize cli defaults, failing start." 1>&2
+    exit 1
+  fi
+fi
+
+COMMAND="${JAVA_BIN} ${JAVA_ARGS} ${LOG_APPENDER} \
+         -cp "$CLASSPATH" \
+         clojure.main -m <%= EZBake::Config[:main_namespace] %> \
+         --config ${CONFIG} --bootstrap-config ${BOOTSTRAP_CONFIG} \
+         --restart-file "${restartfile}" \
+         ${TK_ARGS} \
+         ${@}"
+
+pushd "${INSTALL_DIR}" &> /dev/null
+if [ "$EUID" = "0" ] && command -v runuser &> /dev/null; then
+  runuser "${USER}" -s /bin/bash -c "$COMMAND"
+elif [ "$EUID" = "$(id -u ${USER})" ]; then
+  /bin/bash -c "$COMMAND"
+elif command -v sudo &> /dev/null; then
+  sudo -H -u "${USER}" $COMMAND
+else
+  su "${USER}" -s /bin/bash -c "$COMMAND"
+fi
+popd &> /dev/null

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/foreground.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/foreground.erb
@@ -1,26 +1,20 @@
 #!/usr/bin/env bash
 
 restartfile="/opt/puppetlabs/server/data/<%= EZBake::Config[:real_name] %>/restartcounter"
-cli_defaults=${INSTALL_DIR}/cli/cli-defaults.sh
-
-if [ ! -e "${INSTALL_DIR}/ezbake-functions.sh" ]; then
-    echo "Unable to find ${INSTALL_DIR}/ezbake-functions.sh script, failing start." 1>&2
-    exit 1
+if [ ! -e "$restartfile" ]; then
+  printf '0' | /usr/bin/install -D --owner="${USER:-<%= EZBake::Config[:user] %>}" --group="${GROUP:-<%= EZBake::Config[:group] %>}" --mode=0644 "$restartfile"
 fi
 
-. "${INSTALL_DIR}/ezbake-functions.sh"
-
-init_restart_file "$restartfile" || exit $?
-
-if !(echo "${@}" | grep -e "--debug" -q)
+if ! (echo "${@}" | grep -e "--debug" -q)
 then
     LOG_APPENDER="-Dlogappender=STDOUT"
 fi
 
 CLASSPATH="${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>"
 
+cli_defaults="${INSTALL_DIR}/cli/cli-defaults.sh"
 if [ -e "$cli_defaults" ]; then
-  . $cli_defaults
+  . "$cli_defaults"
   if [ $? -ne 0 ]; then
     echo "Unable to initialize cli defaults, failing start." 1>&2
     exit 1
@@ -28,10 +22,10 @@ if [ -e "$cli_defaults" ]; then
 fi
 
 COMMAND="${JAVA_BIN} ${JAVA_ARGS} ${LOG_APPENDER} \
-         -cp "$CLASSPATH" \
+         -cp '${CLASSPATH}' \
          clojure.main -m <%= EZBake::Config[:main_namespace] %> \
          --config ${CONFIG} --bootstrap-config ${BOOTSTRAP_CONFIG} \
-         --restart-file "${restartfile}" \
+         --restart-file '${restartfile}' \
          ${TK_ARGS} \
          ${@}"
 


### PR DESCRIPTION
foreground is a subcommand for openvox-server and openvoxdb. This this a public interface to our users and removing it is a breaking change.

This fixes a regression introduced in b2de7c7a2e7704491a08665a9f53ded8009aa109