### PR TITLE
systemd unit: Readd reload command

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/debian/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/debian/ezbake.service.erb
@@ -66,6 +66,7 @@ KillMode=process
 <% EZBake::Config[:debian][:post_start_action].each do |action| -%>
 ExecStartPost=-<%= action %>
 <% end -%>
+ExecReload=kill -HUP $MAINPID
 SuccessExitStatus=143
 
 [Install]

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.service.erb
@@ -66,6 +66,7 @@ KillMode=process
 <% EZBake::Config[:redhat][:post_start_action].each do |action| -%>
 ExecStartPost=-<%= action %>
 <% end -%>
+ExecReload=kill -HUP $MAINPID
 SuccessExitStatus=143
 
 [Install]


### PR DESCRIPTION
This fixes a regression from b2de7c7a2e7704491a08665a9f53ded8009aa109 where we removed the reload script. Now that we don't fork anymore, we can just rely on `$MAINPID`, which is a variable provided by systemd.

see https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#ExecReload=