### PR TITLE
ezbake: Introduce service-port variable

### DIFF
--- a/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
@@ -1,5 +1,6 @@
 module EZBake
   Config = {
+      :service_port   => {{{service-port}}},
       :project        => {{{project}}},
       :version        => {{{packaging-version}}},
       :release        => {{{packaging-release}}},

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.service.erb
@@ -63,6 +63,10 @@ ExecStart=<%= EZBake::Config[:java_bin] %> $JAVA_ARGS -Dlogappender=F1 \
 
 KillMode=process
 
+<% if EZBake::Config[:service_port] -%>
+# Wait until the service is started and opened the correct TCP port
+ExecStartPost=timeout 30s sh -c 'while ! ss -H -t -l -n sport = :<%= EZBake::Config[:service_port] %> | grep -q "^LISTEN.*:<%= EZBake::Config[:service_port] %>"; do sleep 1s; done'
+<% end -%>
 <% EZBake::Config[:redhat][:post_start_action].each do |action| -%>
 ExecStartPost=-<%= action %>
 <% end -%>

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -71,6 +71,7 @@
 (def LocalProjectVars
   {(schema/optional-key :user) schema/Str
    (schema/optional-key :numeric-uid-gid) schema/Int
+   (schema/optional-key :service-port) schema/Int
    (schema/optional-key :group) schema/Str
    (schema/optional-key :puppet-platform-version) schema/Int
    (schema/optional-key :bootstrap-source) BootstrapSource
@@ -608,6 +609,7 @@ Additional uberjar dependencies:
      :real-name                          (-> (:name lein-project) get-real-name as-ruby-literal)
      :user                               (local->ruby :user (:name lein-project))
      :numeric-uid-gid                    (local->ruby :numeric-uid-gid nil)
+     :service-port                       (local->ruby :service-port nil)
      :group                              (local->ruby :group (:name lein-project))
      :uberjar-name                       (as-ruby-literal (:uberjar-name lein-project))
      :config-files                       (as-ruby-literal (map remove-erb-extension config-files))

--- a/test/unit/puppetlabs/ezbake/core_test.clj
+++ b/test/unit/puppetlabs/ezbake/core_test.clj
@@ -32,6 +32,7 @@
 (deftest trivial-make-template-map-behavior
   (testing "keyword bootstrap-source value with hyphens is ok"
     (let [expected {:numeric-uid-gid "nil"
+                    :service-port "nil"
                     :debian-prerm "[]"
                     :config-files "[]"
                     :main-namespace "'puppetlabs.trapperkeeper.main'"


### PR DESCRIPTION
This adds a bit of a startup delay to ensure that systemd not just starts the process and thinks the service is already up and running.

Previously this was handled by the wrapper script and Type=forking. This commit fixes a regression from https://github.com/OpenVoxProject/ezbake/commit/b2de7c7a2e7704491a08665a9f53ded8009aa109

This also requires changes to the projects to provide the actual port.

* https://github.com/OpenVoxProject/openvox-server/pull/80
* https://github.com/OpenVoxProject/openvoxdb/pull/69

This is just a workaround and not a perfect solution. For systemd-based systemd we should implement sd_notify and switch to Type=notify-reload.

https://www.freedesktop.org/software/systemd/man/latest/systemd.service.html#Type=