### PR TITLE
systemd: Use restart counter to determine if service is started

### DIFF
--- a/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
@@ -36,8 +36,6 @@ module EZBake
                           :additional_postinst => {{{debian-postinst}}},
                           :additional_postinst_install => {{{debian-postinst-install}}},
                           :additional_install => {{{debian-install}}},
-                          :pre_start_action => {{{debian-pre-start-action}}},
-                          :post_start_action => {{{debian-post-start-action}}},
                           :interested_install_triggers => {
                                                  {{#debian-interested-install-triggers}}
                                                    {{{interest-name}}} => [{{{scripts}}}],
@@ -57,8 +55,6 @@ module EZBake
                           :additional_postinst => {{{redhat-postinst}}},
                           :additional_postinst_install => {{{redhat-postinst-install}}},
                           :additional_install => {{{redhat-install}}},
-                          :pre_start_action => {{{redhat-pre-start-action}}},
-                          :post_start_action => {{{redhat-post-start-action}}},
                           :postinst_install_triggers => {
                                                  {{#redhat-postinst-install-triggers}}
                                                    {{{package}}} => [{{{scripts}}}],

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/debian/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/debian/ezbake.service.erb
@@ -44,13 +44,9 @@ UMask=027
 LimitNOFILE=<%= EZBake::Config[:open_file_limit] %>
 <% end -%>
 
-<% unless EZBake::Config[:debian][:pre_start_action].empty? -%>
-PermissionsStartOnly=true
-<% EZBake::Config[:debian][:pre_start_action].each do |action| -%>
-ExecStartPre=<%= action %>
-<% end -%>
-<% end -%>
-
+# RUNTIME_DIRECTORY is set by systemd
+# https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#RuntimeDirectory=
+ExecStartPre=sh -c "echo -n 0 > ${RUNTIME_DIRECTORY}/restart"
 ExecStart=<%= EZBake::Config[:java_bin] %> $JAVA_ARGS -Dlogappender=F1 \
   '-XX:OnOutOfMemoryError=kill -9 %p' -XX:+CrashOnOutOfMemoryError \
   -XX:ErrorFile="${LOGS_DIRECTORY}/<%= EZBake::Config[:real_name] %>_err_pid%p.log" \
@@ -59,14 +55,18 @@ ExecStart=<%= EZBake::Config[:java_bin] %> $JAVA_ARGS -Dlogappender=F1 \
   -m <%= EZBake::Config[:main_namespace] %> \
   --config "${CONFIG}" \
   --bootstrap-config "${BOOTSTRAP_CONFIG}" \
+  --restart-file ${RUNTIME_DIRECTORY}/restart \
   $TK_ARGS
 
 KillMode=process
 
-<% EZBake::Config[:debian][:post_start_action].each do |action| -%>
-ExecStartPost=-<%= action %>
-<% end -%>
+# wait until the service is actually up
+ExecStartPost=sh -c "sleep 1; while ! head -c1 ${RUNTIME_DIRECTORY}/restart | grep -q '^1'; do kill -0 $MAINPID && sleep 1 || exit 1; done"
+
+ExecReload=sh -c "echo -n 0 > ${RUNTIME_DIRECTORY}/restart"
 ExecReload=kill -HUP $MAINPID
+ExecReload=sh -c "while ! head -c1 ${RUNTIME_DIRECTORY}/restart | grep -q '^1'; do kill -0 $MAINPID && sleep 1 || exit 1; done"
+
 SuccessExitStatus=143
 
 [Install]

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.service.erb
@@ -44,13 +44,9 @@ UMask=027
 LimitNOFILE=<%= EZBake::Config[:open_file_limit] %>
 <% end -%>
 
-<% unless EZBake::Config[:redhat][:pre_start_action].empty? -%>
-PermissionsStartOnly=true
-<% EZBake::Config[:redhat][:pre_start_action].each do |action| -%>
-ExecStartPre=<%= action %>
-<% end -%>
-<% end -%>
-
+# RUNTIME_DIRECTORY is set by systemd
+# https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#RuntimeDirectory=
+ExecStartPre=sh -c "echo -n 0 > ${RUNTIME_DIRECTORY}/restart"
 ExecStart=<%= EZBake::Config[:java_bin] %> $JAVA_ARGS -Dlogappender=F1 \
   '-XX:OnOutOfMemoryError=kill -9 %p' -XX:+CrashOnOutOfMemoryError \
   -XX:ErrorFile="${LOGS_DIRECTORY}/<%= EZBake::Config[:real_name] %>_err_pid%p.log" \
@@ -59,14 +55,18 @@ ExecStart=<%= EZBake::Config[:java_bin] %> $JAVA_ARGS -Dlogappender=F1 \
   -m <%= EZBake::Config[:main_namespace] %> \
   --config "${CONFIG}" \
   --bootstrap-config "${BOOTSTRAP_CONFIG}" \
+  --restart-file ${RUNTIME_DIRECTORY}/restart \
   $TK_ARGS
 
 KillMode=process
 
-<% EZBake::Config[:redhat][:post_start_action].each do |action| -%>
-ExecStartPost=-<%= action %>
-<% end -%>
+# wait until the service is actually up
+ExecStartPost=sh -c "sleep 1; while ! head -c1 ${RUNTIME_DIRECTORY}/restart | grep -q '^1'; do kill -0 $MAINPID && sleep 1 || exit 1; done"
+
+ExecReload=sh -c "echo -n 0 > ${RUNTIME_DIRECTORY}/restart"
 ExecReload=kill -HUP $MAINPID
+ExecReload=sh -c "while ! head -c1 ${RUNTIME_DIRECTORY}/restart | grep -q '^1'; do kill -0 $MAINPID && sleep 1 || exit 1; done"
+
 SuccessExitStatus=143
 
 [Install]

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -624,8 +624,6 @@ Additional uberjar dependencies:
      :debian-postinst                    (val->ruby :debian :postinst)
      :debian-postinst-install            (val->ruby :debian :postinst-install)
      :debian-install                     (val->ruby :debian :install)
-     :debian-pre-start-action            (val->ruby :debian :pre-start-action)
-     :debian-post-start-action           (val->ruby :debian :post-start-action)
      :debian-activated-triggers          (local->ruby :debian-activated-triggers [])
      :debian-interested-install-triggers (map extract-deb-package-scripts
                                               (get-local :debian-interested-install-triggers []))
@@ -637,8 +635,6 @@ Additional uberjar dependencies:
      :redhat-postinst                    (val->ruby :redhat :postinst)
      :redhat-postinst-install            (val->ruby :redhat :postinst-install)
      :redhat-install                     (val->ruby :redhat :install)
-     :redhat-pre-start-action            (val->ruby :redhat :pre-start-action)
-     :redhat-post-start-action           (val->ruby :redhat :post-start-action)
      :terminus-map                       termini
      :replaces-pkgs                      (for [{:keys [package version]}
                                                (get-local :replaces-pkgs [])]

--- a/test/unit/puppetlabs/ezbake/core_test.clj
+++ b/test/unit/puppetlabs/ezbake/core_test.clj
@@ -51,7 +51,6 @@
                     :cli-app-files "[]"
                     :debian-deps "[]"
                     :redhat-deps "[]"
-                    :redhat-post-start-action "[]"
                     :tk-args "''"
                     :replaces-pkgs []
                     :start-before "[]"
@@ -75,12 +74,9 @@
                     :cli-defaults-file "'ext/cli_defaults/cli-defaults.sh'"
                     :debian-install "[]"
                     :redhat-postinst-install-triggers []
-                    :redhat-pre-start-action "[]"
                     :user "'dummy'"
                     :redhat-install "[]"
                     :redhat-postinst-install "[]"
-                    :debian-post-start-action "[]"
-                    :debian-pre-start-action "[]"
                     :debian-preinst "[]"
                     :real-name "'dummy'"
                     :puppet-platform-version "7"


### PR DESCRIPTION
This now uses the same unit files as debian.org in their packages. The restart counter is used to check if the service is already started properly or not. The legacy wrapper scripts from Perforce had the same logic.