### PR TITLE
Add fedora support to controller.sh.erb

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/controller.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/controller.sh.erb
@@ -58,7 +58,7 @@ case $os in
         debian|ubuntu)
                 dir="$basepath/systemd_deb"
                 ;;
-        amazon|el|redhatfips|sles)
+        amazon|el|fedora|redhatfips|sles)
                 dir="$basepath/systemd_el"
                 ;;
         *)


### PR DESCRIPTION
We added it everywhere else, but need to add it here as well.