### PR TITLE
Allow Java 21 for deb packages

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -309,7 +309,7 @@ elsif options.output_type == 'deb'
   end
 
   if ! options.is_pe
-    options.java = 'openjdk-17-jre-headless | openjdk-11-jre-headless'
+    options.java = 'openjdk-21-jre-headless | openjdk-17-jre-headless | openjdk-11-jre-headless'
   end
 
   fpm_opts << '--deb-build-depends cdbs'


### PR DESCRIPTION
Debian 13 only includes 21+

Will do a PR to the main branch as well