### PR TITLE
packaging: Switch from Perforce to OpenVoxProject releases

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/Gemfile
+++ b/resources/puppetlabs/lein-ezbake/template/global/Gemfile
@@ -1,14 +1,5 @@
-source ENV['GEM_SOURCE'] || 'https://rubygems.org/'
+source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
-def location_for(place, fake_version = nil)
-  if place =~ /^(git[:@][^#]*)#(.*)/
-    [fake_version, { :git => $1, :branch => $2, :require => false }].compact
-  elsif place =~ /^file:\/\/(.*)/
-    ['>= 0', { :path => File.expand_path($1), :require => false }]
-  else
-    [place, { :require => false }]
-  end
-end
-
-gem 'packaging', *location_for(ENV['PACKAGING_LOCATION'] || '~> 0.99')
+# 1.0.0 is the first OpenVoxProject release
+gem 'packaging', '~> 1.0', github: 'OpenVoxProject/packaging'
 gem 'fpm'


### PR DESCRIPTION
The Gemfile is a template. For every ezbake based build, the Gemfile is copied into the build dir. Aftwards the gems are installed. the packaging gem is used to publish packages, update repos and render different templates, e.g. the systemd unit files for openvox-server and openvox-db.

As far as I know, the erb template rendering is the only feature from packaging that we use. I didn't want to deal with a new gem name yet, the packaging rubygems namespace is already owned by Perforce: https://rubygems.org/gems/packaging

I assume in the long term we will get rid of packaging, so I didn't bother with renaming the gem. Because of that, we cannot publish it to rubygems.org right. Because of that the Gemfile now uses `github:` to fetch the release from there.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvoxdb & openvox-server. The
packages will be stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archives will be linked at the bottom. It's
always named openvoxerver/openvoxdb-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
