### PR TITLE
Drop tmpfiles.conf

### DIFF
--- a/resources/puppetlabs/lein-ezbake/staging-templates/project_data.yaml.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/project_data.yaml.mustache
@@ -29,8 +29,6 @@ templates:
     target: ext/debian/{{{project}}}.service_file
   - source: ext/ezbake.logrotate.conf.erb
     target: ext/{{{project}}}.logrotate.conf
-  - source: ext/ezbake.tmpfiles.conf.erb
-    target: ext/{{{project}}}.tmpfiles.conf
   - ext/redhat/preinst.erb
   - ext/redhat/postinst.erb
   - ext/redhat/prerm.erb

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake.tmpfiles.conf.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake.tmpfiles.conf.erb
@@ -1,1 +1,0 @@
-d /run/puppetlabs/<%= EZBake::Config[:real_name] %> 0755 <%= EZBake::Config[:user] %> <%= EZBake::Config[:group] %> -

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -265,7 +265,6 @@ if options.output_type == 'rpm'
   fpm_opts << "--rpm-auto-add-exclude-directories /usr/lib/systemd"
   fpm_opts << "--rpm-auto-add-exclude-directories /usr/lib/systemd/system"
   fpm_opts << "--rpm-auto-add-exclude-directories /etc/logrotate.d"
-  fpm_opts << "--rpm-auto-add-exclude-directories /usr/lib/tmpfiles.d"
   fpm_opts << "--rpm-auto-add-exclude-directories /var/log/puppetlabs"
   fpm_opts << "--rpm-auto-add-exclude-directories /var/run/puppetlabs"
   termini_opts << "--rpm-auto-add-exclude-directories /opt/puppetlabs/puppet"

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -159,7 +159,7 @@ if options.sources.empty?
                     when :amazon, :fedora, :sles, :el, :redhatfips
                       ['etc', 'opt', 'usr', 'var']
                     when :debian, :ubuntu
-                      ['etc', 'lib', 'opt', 'usr', 'var']
+                      ['etc', 'lib', 'opt', 'var']
                     else
                       fail "I don't know what your default sources should be, pass it on the command line!"
                     end

--- a/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
@@ -15,7 +15,6 @@ unitdir_redhat=${unitdir:-/usr/lib/systemd/system}
 unitdir_debian=${unitdir:-/lib/systemd/system}
 defaultsdir_redhat=${defaultsdir:-/etc/sysconfig}
 defaultsdir_debian=${defaultsdir:-/etc/default}
-tmpfilesdir=${tmpfilesdir:=/usr/lib/tmpfiles.d}
 datadir=${datadir:=${prefix}/share}
 real_name=${real_name:=<%= EZBake::Config[:real_name] -%>}
 projdatadir=${projdatadir:=${datadir}/${real_name}}
@@ -229,8 +228,6 @@ function task_systemd_redhat {
     task defaults_redhat
     install -d -m 0755 "${DESTDIR}${unitdir_redhat}"
     install -m 0644 ext/redhat/<%= EZBake::Config[:project] %>.service "${DESTDIR}${unitdir_redhat}/<%= EZBake::Config[:project] %>.service"
-    install -d -m 0755 "${DESTDIR}${tmpfilesdir}"
-    install -m 0644 ext/<%= EZBake::Config[:project] %>.tmpfiles.conf "${DESTDIR}${tmpfilesdir}/<%= EZBake::Config[:project] %>.conf"
 }
 
 # Install the systemd and defaults configuration for Debian.
@@ -238,8 +235,6 @@ function task_systemd_deb {
     task defaults_deb
     install -d -m 0755 "${DESTDIR}${unitdir_debian}"
     install -m 0644 ext/debian/<%= EZBake::Config[:project] %>.service_file "${DESTDIR}${unitdir_debian}/<%= EZBake::Config[:project] %>.service"
-    install -d -m 0755 "${DESTDIR}${tmpfilesdir}"
-    install -m 0644 ext/<%= EZBake::Config[:project] %>.tmpfiles.conf "${DESTDIR}${tmpfilesdir}/<%= EZBake::Config[:project] %>.conf"
 }
 
 function task_service_account {


### PR DESCRIPTION
The tmpfiles configuration file isn't required anymore, since we set PrivateTmp=true in the systemd unit (introduced in 900b4eee0dfda861fd99934ce5f1532c411ab373).

---

The `/usr` directory contains only two files:

```
/usr
/usr/lib
/usr/lib/tmpfiles.d
/usr/lib/tmpfiles.d/puppetserver.conf
/usr/share
/usr/share/doc
/usr/share/doc/openvox-server
/usr/share/doc/openvox-server/changelog.gz
```

We don't package /usr/lib/tmpfiles.d/*.conf anymore. And the changelog.gz is autogenerated by fpm afterwards. That means that in our packaging directory, there is no `/usr`. If we force fpm to package it, it will raise an error.