### PR TITLE
Remove sysvinit leftovers

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
@@ -11,7 +11,6 @@ USE_TASKSMAX=${USE_TASKSMAX:-true}
 # Warning: This variable API is experimental so these variables may be subject
 # to change in the future.
 prefix=${prefix:=/usr}
-initdir=${initdir:=/etc/init.d}
 unitdir_redhat=${unitdir:-/usr/lib/systemd/system}
 unitdir_debian=${unitdir:-/lib/systemd/system}
 defaultsdir_redhat=${defaultsdir:-/etc/sysconfig}


### PR DESCRIPTION
The variable isn't used anymore. `git grep initdir` doesn't find anything.


(cherry picked from commit ae5adcf24ccab9692507ffbd080c9f93b02419f1)

This is probably a leftover from a rebase.