### PR TITLE
Provide explicit JRE dependencies and bin paths for each OS version

### DIFF
--- a/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
@@ -73,6 +73,7 @@ module EZBake
       :main_namespace => {{{main-namespace}}},
       :java_args      => {{{java-args}}},
       :java_args_cli  => {{{java-args-cli}}},
+      :java_bin       => {{{java-bin}}},
       :tk_args        => {{{tk-args}}},
       :start_before   => {{{start-before}}},
       :start_after    => {{{start-after}}},

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/default.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/default.erb
@@ -2,9 +2,6 @@
 # Init settings for <%= EZBake::Config[:project] %>
 ###########################################
 
-# Location of your Java binary (version 8)
-JAVA_BIN="/usr/bin/java"
-
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
 JAVA_ARGS="<%= EZBake::Config[:java_args] %>"
 

--- a/resources/puppetlabs/lein-ezbake/template/foss/ext/default.erb
+++ b/resources/puppetlabs/lein-ezbake/template/foss/ext/default.erb
@@ -2,6 +2,9 @@
 # Init settings for <%= EZBake::Config[:project] %>
 ###########################################
 
+# Location of your Java binary
+JAVA_BIN="<%= EZBake::Config[:java_bin] %>"
+
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
 JAVA_ARGS="<%= EZBake::Config[:java_args] %>"
 

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -10,6 +10,7 @@ options.systemd_el = 0
 options.systemd_sles = 0
 options.sles = 0
 options.java = 'java-1.8.0-openjdk-headless'
+options.java_bin = '/usr/bin/java'
 options.release = 1
 options.platform_version = 0
 options.replaces = {}

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -5,12 +5,36 @@ require 'optparse'
 require 'ostruct'
 
 options = OpenStruct.new
+
+# ezbake.rb is rendered from
+# resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
+#
+# inside the build container, fpm.rb is at:
+# /code/target/staging/puppetserver-8.9.0/ext/fpm.rb
+# ezbake:
+# /code/target/staging/ezbake.rb
+#
+# we do this hula hoop jump because in our build process the ezbake.rb exists
+# We also distribute a .tar.gz. This contains the compiled jar + fpm.rb.
+# fpm.rb is executed while we build the packages. This is the same process as
+# compiling the jar and rendering ezbake from
+# resources/puppetlabs/lein-ezbake/staging-templates/ezbake.rb.mustache
+# people that try to build their own package based on our tar, like FreeBSD, don't have the ezbake.rb
+#
+# patches welcome to move ezbake.rb into the tar *or* get rid of ezbake
+begin
+  require_relative '../../ezbake'
+rescue LoadError
+  options.java_bin = '/usr/bin/java'
+else
+  options.java_bin = EZBake::Config[:java_bin]
+end
+
 # settin' some defaults
 options.systemd_el = 0
 options.systemd_sles = 0
 options.sles = 0
 options.java = 'java-1.8.0-openjdk-headless'
-options.java_bin = '/usr/bin/java'
 options.release = 1
 options.platform_version = 0
 options.replaces = {}

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -166,6 +166,10 @@ if options.sources.empty?
 end
 options.dist = "#{options.operating_system}#{options.os_version}" if options.dist.nil?
 
+# values can be... unexpected, so log them
+warn "options.os_version is: #{options.os_version}"
+warn "options.dist is: #{options.dist}"
+
 fpm_opts = Array('')
 shared_opts = Array('')
 termini_opts = Array('')
@@ -294,8 +298,6 @@ elsif options.output_type == 'deb'
     options.release = "#{options.release}+#{options.dist}"
   end
 
-  options.java = 'openjdk-21-jre-headless | openjdk-17-jre-headless'
-
   fpm_opts << '--deb-build-depends cdbs'
   fpm_opts << '--deb-build-depends bc'
   fpm_opts << '--deb-build-depends mawk'
@@ -309,6 +311,37 @@ elsif options.output_type == 'deb'
 
    options.deb_activate_triggers.each do |trigger|
     fpm_opts << "--deb-activate #{trigger}"
+  end
+
+  # figure out correct java dependency
+  case options.dist
+  when 'debian11' # Bullseye
+    options.java = 'openjdk-17-jre-headless'
+    options.java_bin = '/usr/lib/jvm/java-17-openjdk-amd64/bin/java'
+  when 'debian12' # Bookworm
+    options.java = 'openjdk-17-jre-headless'
+    options.java_bin = '/usr/lib/jvm/java-17-openjdk-amd64/bin/java'
+  when 'debian13' # Trixie
+    options.java = 'openjdk-21-jre-headless'
+    options.java_bin = '/usr/lib/jvm/java-21-openjdk-amd64/bin/java'
+  when 'ubuntu20.04' # Focal Fossa
+    options.java = 'openjdk-21-jre-headless'
+    options.java_bin = '/usr/lib/jvm/java-21-openjdk-amd64/bin/java'
+  when 'ubuntu22.04' # Jammy Jellyfish
+    options.java = 'openjdk-21-jre-headless'
+    options.java_bin = '/usr/lib/jvm/java-21-openjdk-amd64/bin/java'
+  when 'ubuntu24.04' # Noble Numbat
+    options.java = 'openjdk-21-jre-headless'
+    options.java_bin = '/usr/lib/jvm/java-21-openjdk-amd64/bin/java'
+  when 'ubuntu25.04' # Plucky Puffin
+    options.java = 'openjdk-21-jre-headless'
+    options.java_bin = '/usr/lib/jvm/java-21-openjdk-amd64/bin/java'
+  when 'ubuntu25.10' # Questing Quokka
+    options.java = 'openjdk-21-jre-headless'
+    options.java_bin = '/usr/lib/jvm/java-21-openjdk-amd64/bin/java'
+  when 'ubuntu26.04' # Resolute Raccoon
+    options.java = 'openjdk-21-jre-headless'
+    options.java_bin = '/usr/lib/jvm/java-21-openjdk-amd64/bin/java'
   end
 end
 

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -315,33 +315,16 @@ elsif options.output_type == 'deb'
 
   # figure out correct java dependency
   case options.dist
-  when 'debian11' # Bullseye
+  # Bullseye, Bookworm
+  when 'debian11','debian12'
     options.java = 'openjdk-17-jre-headless'
     options.java_bin = '/usr/lib/jvm/java-17-openjdk-amd64/bin/java'
-  when 'debian12' # Bookworm
-    options.java = 'openjdk-17-jre-headless'
-    options.java_bin = '/usr/lib/jvm/java-17-openjdk-amd64/bin/java'
-  when 'debian13' # Trixie
+  # Trixie, Focal Fossa, Jammy Jellyfish, Noble Numbat, Plucky Puffin, Questing Quokka, Resolute Raccoon
+  when 'debian13', 'ubuntu20.04', 'ubuntu22.04', 'ubuntu24.04', 'ubuntu25.04', 'ubuntu25.10', 'ubuntu26.04'
     options.java = 'openjdk-21-jre-headless'
     options.java_bin = '/usr/lib/jvm/java-21-openjdk-amd64/bin/java'
-  when 'ubuntu20.04' # Focal Fossa
-    options.java = 'openjdk-21-jre-headless'
-    options.java_bin = '/usr/lib/jvm/java-21-openjdk-amd64/bin/java'
-  when 'ubuntu22.04' # Jammy Jellyfish
-    options.java = 'openjdk-21-jre-headless'
-    options.java_bin = '/usr/lib/jvm/java-21-openjdk-amd64/bin/java'
-  when 'ubuntu24.04' # Noble Numbat
-    options.java = 'openjdk-21-jre-headless'
-    options.java_bin = '/usr/lib/jvm/java-21-openjdk-amd64/bin/java'
-  when 'ubuntu25.04' # Plucky Puffin
-    options.java = 'openjdk-21-jre-headless'
-    options.java_bin = '/usr/lib/jvm/java-21-openjdk-amd64/bin/java'
-  when 'ubuntu25.10' # Questing Quokka
-    options.java = 'openjdk-21-jre-headless'
-    options.java_bin = '/usr/lib/jvm/java-21-openjdk-amd64/bin/java'
-  when 'ubuntu26.04' # Resolute Raccoon
-    options.java = 'openjdk-21-jre-headless'
-    options.java_bin = '/usr/lib/jvm/java-21-openjdk-amd64/bin/java'
+  else
+    fail "no matching OS data found for #{options.dist}"
   end
 end
 

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -108,6 +108,7 @@
    (schema/optional-key :main-namespace) schema/Str
    (schema/optional-key :java-args) schema/Str
    (schema/optional-key :java-args-cli) schema/Str
+   (schema/optional-key :java-bin) schema/Str
    (schema/optional-key :tk-args) schema/Str
    (schema/optional-key :redhat-postinst-install-triggers) RPMTriggers
    (schema/optional-key :redhat-postinst-upgrade-triggers) RPMTriggers
@@ -802,6 +803,8 @@ Additional uberjar dependencies:
      :java-args                          (local->ruby :java-args
                                                       "-Xmx192m")
      :java-args-cli                      (local->ruby :java-args-cli "")
+     :java-bin                           (local->ruby :java-bin
+                                                      "/usr/bin/java")
      :tk-args                            (local->ruby :tk-args "")
      :bootstrap-source                   (-> (get-local :bootstrap-source :bootstrap-cfg)
                                              name as-ruby-literal)

--- a/test/unit/puppetlabs/ezbake/core_test.clj
+++ b/test/unit/puppetlabs/ezbake/core_test.clj
@@ -71,6 +71,7 @@
                     :project "'dummy'"
                     :debian-postinst-install "[]"
                     :java-args-cli "''"
+                    :java-bin "'/usr/bin/java'"
                     :cli-defaults-file "'ext/cli_defaults/cli-defaults.sh'"
                     :debian-install "[]"
                     :redhat-postinst-install-triggers []


### PR DESCRIPTION
This is a minimal / cleaned up version of https://github.com/OpenVoxProject/ezbake/pull/61. It introduces two OS specific options, `java` and `java_bin`. The first is the name of a specific JRE package that we want to depend on. We depend on JRE 21 where available, otherwise 17. `java_bin` points to the Java binary. **This OS-specific value is currently not used**. In a future PR, we will update the systemd units to directly start the process via `java_bin`, instead of the wrapper script.