### PR TITLE
Fall back to resolving classpath-jar artifacts from managed-dependencies

### DIFF
--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -413,6 +413,8 @@ Additional uberjar dependencies:
    find the corresponding jar file on the resolved classpath. For artifacts where
    the group-id equals the artifact-id (e.g., commons-io), an unqualified symbol
    like 'commons-io may be used.
+   Falls back to resolving the artifact independently using the version from
+   :managed-dependencies if not found on the classpath.
    Returns the File for the jar, or nil if not found."
   [lein-project artifact-symbol :- schema/Symbol]
   (let [group-id (or (namespace artifact-symbol) (name artifact-symbol))
@@ -421,13 +423,30 @@ Additional uberjar dependencies:
                                         (java.util.regex.Pattern/quote artifact-id)))
         group-path (str/replace group-id "." "/")
         classifier-pattern #"-(sources|javadoc|tests)\.jar$"
-        classpath-jars (lein-classpath/resolve-managed-dependencies
-                        :dependencies :managed-dependencies lein-project)]
-    (->> classpath-jars
-         (filter #(and (re-find jar-pattern (.getPath %))
-                       (str/includes? (.getPath %) group-path)
-                       (not (re-find classifier-pattern (.getPath %)))))
-         first)))
+        find-jar (fn [jars]
+                   (->> jars
+                        (filter #(and (re-find jar-pattern (.getPath %))
+                                      (str/includes? (.getPath %) group-path)
+                                      (not (re-find classifier-pattern (.getPath %)))))
+                        first))
+        jar (find-jar (lein-classpath/resolve-managed-dependencies
+                        :dependencies :managed-dependencies lein-project))]
+    (or jar
+        (let [artifact-sym (symbol group-id artifact-id)
+              version (->> (:managed-dependencies lein-project)
+                           (filter #(= (first %) artifact-sym))
+                           first
+                           second)]
+          (if version
+            (do
+              (lein-main/info (format "Resolving %s %s independently (not on classpath)"
+                                      artifact-sym version))
+              (find-jar (lein-classpath/resolve-managed-dependencies
+                          :dependencies nil
+                          {:dependencies [[artifact-sym version]]
+                           :repositories (:repositories lein-project)})))
+            (lein-main/info (format "No version found in :managed-dependencies for %s"
+                                    artifact-sym)))))))
 
 (schema/defn cp-classpath-jar-to-staging
   "Copy a single jar from the classpath to the staging directory.


### PR DESCRIPTION
When a classpath-jar artifact is not found in the project's resolved dependencies, resolve it independently using the version pinned in :managed-dependencies. This allows projects to use :classpath-jars for artifacts that cannot coexist on the JVM classpath (e.g. FIPS and non-FIPS BouncyCastle jars which conflict due to sealed packages) without requiring them in :dependencies.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvoxdb & openvox-server. The
packages will be stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archives will be linked at the bottom. It's
always named openvoxerver/openvoxdb-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
