### PR TITLE
Remove use of deprecated bundler flags

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2'
+          ruby-version: '4.0'
           bundler-cache: true
           working-directory: resources/puppetlabs/lein-ezbake/template/global
       - run: bundle env
@@ -88,7 +88,7 @@ jobs:
           - project: openvoxdb
             repository: 'OpenVoxProject/openvoxdb'
     steps:
-      - name: checkout openvox-server
+      - name: Checkout repository
         uses: actions/checkout@v6
         with:
           repository: ${{ matrix.repository }}
@@ -97,10 +97,28 @@ jobs:
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2'
+          ruby-version: '4.0'
           bundler-cache: true
       - name: Display Ruby environment
         run: bundle env
+      - id: docker-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: /tmp/ezbake-builder.tar
+          key: docker-ezbake-${{ matrix.project }}-${{ hashFiles('Dockerfile') }}
+      - name: Load or build Docker image
+        run: |
+          if [[ -f /tmp/ezbake-builder.tar ]]; then
+            docker load -i /tmp/ezbake-builder.tar
+          else
+            docker build -t ezbake-builder .
+            docker save ezbake-builder -o /tmp/ezbake-builder.tar
+          fi
+      - uses: actions/cache/save@v4
+        if: always() && steps.docker-cache.outputs.cache-hit != 'true'
+        with:
+          path: /tmp/ezbake-builder.tar
+          key: docker-ezbake-${{ matrix.project }}-${{ hashFiles('Dockerfile') }}
       - name: get ${{ matrix.project }} version
         id: version
         run: |

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -1154,7 +1154,9 @@ Additional uberjar dependencies:
 (defmethod action "build"
   [_ lein-project build-target]
   (action "stage" lein-project build-target)
-  (exec/exec "bundle" "install" "--path" ".bundle/gems" "--binstubs" ".bundle/bin" :dir staging-dir)
+  (exec/exec "bundle" "config" "set" "--local" "path" ".bundle/gems" :dir staging-dir)
+  (exec/exec "bundle" "config" "set" "--local" "bin" ".bundle/bin" :dir staging-dir)
+  (exec/exec "bundle" "install" :dir staging-dir)
   (let [downstream-job nil
         rake-call ["bundle" "exec" "rake" "pl:jenkins:trigger_build_local_auth"]]
     (exec/lazy-sh rake-call {:dir staging-dir})))
@@ -1162,7 +1164,9 @@ Additional uberjar dependencies:
 (defmethod action "local-build"
   [_ lein-project build-target]
   (action "stage" lein-project build-target)
-  (exec/exec "bundle" "install" "--path" ".bundle/gems" "--binstubs" ".bundle/bin" :dir staging-dir)
+  (exec/exec "bundle" "config" "set" "--local" "path" ".bundle/gems" :dir staging-dir)
+  (exec/exec "bundle" "config" "set" "--local" "bin" ".bundle/bin" :dir staging-dir)
+  (exec/exec "bundle" "install" :dir staging-dir)
   (let [downstream-job nil
         rake-call ["bundle" "exec" "rake" "pl:local_build"]]
     (exec/lazy-sh rake-call {:dir staging-dir})))


### PR DESCRIPTION
In Ruby 4, you are explicitly blocked from using the --path flag due to it not being remembered across bundler invocations.

Also updates the PR check to use the new docker image caching scheme.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvoxdb & openvox-server. The
packages will be stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archives will be linked at the bottom. It's
always named openvoxerver/openvoxdb-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
