### PR TITLE
Add ostruct to global Gemfile

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/Gemfile
+++ b/resources/puppetlabs/lein-ezbake/template/global/Gemfile
@@ -3,3 +3,4 @@ source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 # 1.0.0 is the first OpenVoxProject release
 gem 'packaging', '~> 1.0', github: 'OpenVoxProject/packaging'
 gem 'fpm'
+gem 'ostruct'


### PR DESCRIPTION
The fpm script requires ostruct, and Ruby 4 no longer ships it by default, so we must add it to the global Gemfile.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvoxdb & openvox-server. The
packages will be stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archives will be linked at the bottom. It's
always named openvoxerver/openvoxdb-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
