### PR TITLE
use --macros flag in rpmbuild for SLES 15

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -4,6 +4,7 @@ require 'fileutils'
 require 'open3'
 require 'optparse'
 require 'ostruct'
+require 'tmpdir'
 
 def patch_files(options)
   if options.java_bin == EZBake::Config[:java_bin]
@@ -37,6 +38,26 @@ def patch_files(options)
       FileUtils.mv(path, original)
     end
   end
+end
+
+def create_sles_rpmbuild_wrapper
+  # This wrapper allows us to use the RPM macros from the systemd-rpm-macros
+  # opensuse package by supplying the --macros flag to rpmbuild.
+  wrapper_dir = Dir.mktmpdir('sles-rpmbuild-wrapper')
+  wrapper_path = File.join(wrapper_dir, 'rpmbuild')
+
+  File.write(wrapper_path, <<~'SH')
+    #!/bin/sh
+
+    echo "Invoking rpmbuild wrapper with --macros flag" >&2
+
+    exec /usr/bin/rpmbuild \
+      --macros "/opt/suse-rpm-macros/usr/lib/rpm/macros.d/macros.systemd:/usr/lib/rpm/macros:/usr/lib/rpm/macros.d/*" \
+      "$@"
+  SH
+
+  FileUtils.chmod(0755, wrapper_path)
+  wrapper_dir
 end
 
 options = OpenStruct.new
@@ -248,6 +269,7 @@ if options.output_type == 'rpm'
     options.sles = 1
     options.java = 'java-25-openjdk-headless'
     options.java_bin = '/usr/lib64/jvm/jre-25/bin/java'
+    options.rpmbuild_wrapper_dir = create_sles_rpmbuild_wrapper
   else
     fail "Unrecognized OS #{options.operating_system} version #{options.os_version}"
   end
@@ -484,9 +506,15 @@ if options.debug
   puts "#{Dir.pwd}"
 end
 
+env = {}
+if options.rpmbuild_wrapper_dir
+  # modify PATH to include the rpmbuild wrapper dir (if necessary)
+  env['PATH'] = "#{options.rpmbuild_wrapper_dir}:#{ENV['PATH']}"
+end
+
 patch_files(options) do
   # fpm sends all output to stdout
-  out, _, stat = Open3.capture3("#{fpm_editor} fpm #{fpm_opts.join(' ')}")
+  out, _, stat = Open3.capture3(env, "#{fpm_editor} fpm #{fpm_opts.join(' ')}")
   fail "Error trying to run FPM for #{options.dist}!\n#{out}" unless stat.success?
 
   puts "#{out}"


### PR DESCRIPTION
On SLES, the package uses %service_del_preun and %service_del_postun macros but doesn't declare systemd-rpm-macros as a build dependency.

This causes the macros to be incorrectly expanded or missing, resulting in scriptlet failures during package removal on SLES15:

  error: %preun(openvox-server) scriptlet failed, exit status 1
  /var/tmp/rpm-tmp.XXX: line 1: fg: no job control