### PR TITLE
fpm: Don't set --rpm-rpmbuild-define

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -183,7 +183,6 @@ options.app_data = "/opt/puppetlabs/server/data/#{options.realname}"
 if options.output_type == 'rpm'
 
   shared_opts << "--rpm-digest sha256"
-  shared_opts << "--rpm-rpmbuild-define 'rpmversion #{options.version}'"
   fpm_opts << "--rpm-rpmbuild-define '_app_logdir #{options.app_logdir}'"
   fpm_opts << "--rpm-rpmbuild-define '_app_rundir #{options.app_rundir}'"
   fpm_opts << "--rpm-rpmbuild-define '_app_prefix #{options.app_prefix}'"


### PR DESCRIPTION
under the hood, fpm calls rpmbuild. Under EL9, the fpm option `--rpm-rpmbuild-define` worked fine and was set to the version of the actual package. This was probably never correct. It maps to the rpm macro `%rpmversion`. This is supposed to be used for the *rpm* version used during the build. rpmbuild on EL10 will set `%rpmversion` automatically and fpm cannot provide it as well. We also set the actual version here:

```
shared_opts << "--version #{options.version}"
```

And this is around since the introduction of fpm in ba3315c103bf70a8a0761c2c0af9c7159a08660c.

Also Zhenech confirmed that we can remove `--rpm-rpmbuild-define`.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvoxdb & openvox-server. The
packages will be stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archives will be linked at the bottom. It's
always named openvoxerver/openvoxdb-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
