### PR TITLE
Revert "(EZ-46) Install tmpfiles.d config on systemd platforms"

### DIFF
--- a/resources/puppetlabs/lein-ezbake/staging-templates/project_data.yaml.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/project_data.yaml.mustache
@@ -29,8 +29,6 @@ templates:
     target: ext/debian/{{{project}}}.service_file
   - source: ext/ezbake.logrotate.conf.erb
     target: ext/{{{project}}}.logrotate.conf
-  - source: ext/ezbake.tmpfiles.conf.erb
-    target: ext/{{{project}}}.tmpfiles.conf
   - ext/redhat/preinst.erb
   - ext/redhat/postinst.erb
   - ext/redhat/prerm.erb

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake.tmpfiles.conf.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/ezbake.tmpfiles.conf.erb
@@ -1,1 +1,0 @@
-d /run/puppetlabs/<%= EZBake::Config[:real_name] %> 0755 <%= EZBake::Config[:user] %> <%= EZBake::Config[:group] %> -

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -195,7 +195,7 @@ if options.sources.empty?
                     when :amazon, :fedora, :sles, :el, :redhatfips
                       ['etc', 'opt', 'usr', 'var']
                     when :debian, :ubuntu
-                      ['etc', 'lib', 'opt', 'usr', 'var']
+                      ['etc', 'lib', 'opt', 'var']
                     else
                       fail "I don't know what your default sources should be, pass it on the command line!"
                     end

--- a/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/install.sh.erb
@@ -15,7 +15,6 @@ unitdir_redhat=${unitdir:-/usr/lib/systemd/system}
 unitdir_debian=${unitdir:-/lib/systemd/system}
 defaultsdir_redhat=${defaultsdir:-/etc/sysconfig}
 defaultsdir_debian=${defaultsdir:-/etc/default}
-tmpfilesdir=${tmpfilesdir:=/usr/lib/tmpfiles.d}
 datadir=${datadir:=${prefix}/share}
 real_name=${real_name:=<%= EZBake::Config[:real_name] -%>}
 projdatadir=${projdatadir:=${datadir}/${real_name}}
@@ -226,8 +225,6 @@ function task_systemd_redhat {
     task defaults_redhat
     install -d -m 0755 "${DESTDIR}${unitdir_redhat}"
     install -m 0644 ext/redhat/<%= EZBake::Config[:project] %>.service "${DESTDIR}${unitdir_redhat}/<%= EZBake::Config[:project] %>.service"
-    install -d -m 0755 "${DESTDIR}${tmpfilesdir}"
-    install -m 0644 ext/<%= EZBake::Config[:project] %>.tmpfiles.conf "${DESTDIR}${tmpfilesdir}/<%= EZBake::Config[:project] %>.conf"
 }
 
 # Install the systemd and defaults configuration for Debian.
@@ -236,7 +233,6 @@ function task_systemd_deb {
     install -d -m 0755 "${DESTDIR}${unitdir_debian}"
     install -m 0644 ext/debian/<%= EZBake::Config[:project] %>.service_file "${DESTDIR}${unitdir_debian}/<%= EZBake::Config[:project] %>.service"
     install -d -m 0755 "${DESTDIR}${tmpfilesdir}"
-    install -m 0644 ext/<%= EZBake::Config[:project] %>.tmpfiles.conf "${DESTDIR}${tmpfilesdir}/<%= EZBake::Config[:project] %>.conf"
 }
 
 function task_service_account {


### PR DESCRIPTION
This reverts commit 814ee0cc8476db873239fc60b8b8a93a99e1abe3.

Since the merge of https://github.com/OpenVoxProject/ezbake/pull/103, we switched the systemd unit from `Type=forking` to `Type=notify-reload`. Because of that, systemd can properly track the process and doesn't need the pidfile anymore. Because of that, we can revert 814ee0cc8476db873239fc60b8b8a93a99e1abe3. This was partially done in https://github.com/OpenVoxProject/ezbake/pull/5 and https://github.com/OpenVoxProject/ezbake/pull/22 but reverted when we switched the main/dev branches.

---

https://github.com/OpenVoxProject/ezbake/pull/104 is the proper successor of https://github.com/OpenVoxProject/ezbake/pull/91.
