### PR TITLE
Ubuntu / Debian: Make deb packages depend on Java 25 where possible

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -348,10 +348,14 @@ elsif options.output_type == 'deb'
   when 'debian11','debian12'
     options.java = 'openjdk-17-jre-headless'
     options.java_bin = '/usr/lib/jvm/java-17-openjdk-amd64/bin/java'
-  # Trixie, Focal Fossa, Jammy Jellyfish, Noble Numbat, Plucky Puffin, Questing Quokka, Resolute Raccoon
-  when 'debian13', 'ubuntu20.04', 'ubuntu22.04', 'ubuntu24.04', 'ubuntu25.04', 'ubuntu25.10', 'ubuntu26.04'
+  # Trixie, Focal Fossa,
+  when 'debian13', 'ubuntu20.04'
     options.java = 'openjdk-21-jre-headless'
     options.java_bin = '/usr/lib/jvm/java-21-openjdk-amd64/bin/java'
+  # Noble Numbat, Plucky Puffin, Questing Quokka, Resolute Raccoon
+  when 'ubuntu22.04', 'ubuntu24.04', 'ubuntu25.04', 'ubuntu25.10', 'ubuntu26.04'
+    options.java = 'openjdk-25-jre-headless'
+    options.java_bin = '/usr/lib/jvm/java-25-openjdk-amd64/bin/java'
   else
     fail "no matching OS data found for #{options.dist}"
   end

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -352,8 +352,8 @@ elsif options.output_type == 'deb'
   when 'debian13', 'ubuntu20.04'
     options.java = 'openjdk-21-jre-headless'
     options.java_bin = '/usr/lib/jvm/java-21-openjdk-amd64/bin/java'
-  # Noble Numbat, Plucky Puffin, Questing Quokka, Resolute Raccoon
-  when 'ubuntu22.04', 'ubuntu24.04', 'ubuntu25.04', 'ubuntu25.10', 'ubuntu26.04'
+  # Noble Numbat, Plucky Puffin, Questing Quokka, Resolute Raccoon, Stonking Stingray
+  when 'ubuntu22.04', 'ubuntu24.04', 'ubuntu25.04', 'ubuntu25.10', 'ubuntu26.04', 'ubuntu26.10'
     options.java = 'openjdk-25-jre-headless'
     options.java_bin = '/usr/lib/jvm/java-25-openjdk-amd64/bin/java'
   else

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -352,8 +352,8 @@ elsif options.output_type == 'deb'
   when 'ubuntu20.04'
     options.java = 'openjdk-21-jre-headless'
     options.java_bin = '/usr/lib/jvm/java-21-openjdk-amd64/bin/java'
-  # Trixie, Noble Numbat, Plucky Puffin, Questing Quokka, Resolute Raccoon, Stonking Stingray
-  when 'debian13', 'ubuntu22.04', 'ubuntu24.04', 'ubuntu25.04', 'ubuntu25.10', 'ubuntu26.04', 'ubuntu26.10'
+  # Trixie, Forky, Noble Numbat, Plucky Puffin, Questing Quokka, Resolute Raccoon, Stonking Stingray
+  when 'debian13', 'debian14', 'ubuntu22.04', 'ubuntu24.04', 'ubuntu25.04', 'ubuntu25.10', 'ubuntu26.04', 'ubuntu26.10'
     options.java = 'openjdk-25-jre-headless'
     options.java_bin = '/usr/lib/jvm/java-25-openjdk-amd64/bin/java'
   else

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -349,11 +349,11 @@ elsif options.output_type == 'deb'
     options.java = 'openjdk-17-jre-headless'
     options.java_bin = '/usr/lib/jvm/java-17-openjdk-amd64/bin/java'
   # Trixie, Focal Fossa,
-  when 'debian13', 'ubuntu20.04'
+  when 'ubuntu20.04'
     options.java = 'openjdk-21-jre-headless'
     options.java_bin = '/usr/lib/jvm/java-21-openjdk-amd64/bin/java'
-  # Noble Numbat, Plucky Puffin, Questing Quokka, Resolute Raccoon, Stonking Stingray
-  when 'ubuntu22.04', 'ubuntu24.04', 'ubuntu25.04', 'ubuntu25.10', 'ubuntu26.04', 'ubuntu26.10'
+  # Trixie, Noble Numbat, Plucky Puffin, Questing Quokka, Resolute Raccoon, Stonking Stingray
+  when 'debian13', 'ubuntu22.04', 'ubuntu24.04', 'ubuntu25.04', 'ubuntu25.10', 'ubuntu26.04', 'ubuntu26.10'
     options.java = 'openjdk-25-jre-headless'
     options.java_bin = '/usr/lib/jvm/java-25-openjdk-amd64/bin/java'
   else


### PR DESCRIPTION
We support/test against Java 21 and 25 in our openvoxdb/openvox-server pipelines. Our packages depend on either of those versions. Where possible, we want to use Java 25. This also adds Debian 14 / Ubuntu 26.10 to the list. They are still in development, but it's already clear that they will ship Java 25 as well. See individual commits for details.