### PR TITLE
EL8: Use Java 21; EL9/10: Use Java 25

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -235,11 +235,11 @@ if options.output_type == 'rpm'
   elsif options.operating_system == :el || options.operating_system == :redhatfips
     if options.os_version <= 7
       raise "el version #{options.os_version} is no longer supported"
-    elsif (8..9).include?(options.os_version)
-      options.java = 'jre-17-headless'
-      options.java_bin = '/usr/lib/jvm/jre-17/bin/java'
-    elsif options.os_version >= 10
+    elsif options.os_version == 8
       options.java = 'jre-21-headless'
+      options.java_bin = '/usr/lib/jvm/jre-21/bin/java'
+    elsif options.os_version >= 9
+      options.java = 'jre-25-headless'
       options.java_bin = '/usr/lib/jvm/jre-21/bin/java'
     else
       fail "Unrecognized el os version #{options.os_version}"


### PR DESCRIPTION
openvoxdb and openvox-server start fine with Java 25 (the binary is still compiled with Java 21).

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvoxdb & openvox-server. The
packages will be stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archives will be linked at the bottom. It's
always named openvoxerver/openvoxdb-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
