### PR TITLE
Standardize on CrashOnOutOfMemoryError

### DIFF
--- a/resources/puppetlabs/lein-ezbake/staging-templates/Dockerfile.mustache
+++ b/resources/puppetlabs/lein-ezbake/staging-templates/Dockerfile.mustache
@@ -8,5 +8,5 @@ VOLUME /ssl
 
 {{{expose-ports}}}
 
-ENTRYPOINT java -Djava.security.egd=/dev/urandom -XX:OnOutOfMemoryError="kill -9 %p" -cp "{{{classpath}}}" clojure.main -m puppetlabs.trapperkeeper.main --config /config/conf.d --bootstrap-config /config/bootstrap.cfg
+ENTRYPOINT java -Djava.security.egd=/dev/urandom -XX:+CrashOnOutOfMemoryError -cp "{{{classpath}}}" clojure.main -m puppetlabs.trapperkeeper.main --config /config/conf.d --bootstrap-config /config/bootstrap.cfg
 

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/debian/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/debian/ezbake.service.erb
@@ -52,7 +52,7 @@ ExecStartPre=<%= action %>
 <% end -%>
 
 ExecStart=<%= EZBake::Config[:java_bin] %> $JAVA_ARGS $LOG_APPENDER -Dlogappender=F1 \
-  '-XX:OnOutOfMemoryError=kill -9 %p' -XX:+CrashOnOutOfMemoryError \
+  -XX:+CrashOnOutOfMemoryError \
   -XX:ErrorFile="${LOGS_DIRECTORY}/<%= EZBake::Config[:real_name] %>_err_pid%p.log" \
   -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" \
   clojure.main \

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.service.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/redhat/ezbake.service.erb
@@ -52,7 +52,7 @@ ExecStartPre=<%= action %>
 <% end -%>
 
 ExecStart=<%= EZBake::Config[:java_bin] %> $JAVA_ARGS -Dlogappender=F1 \
-  '-XX:OnOutOfMemoryError=kill -9 %p' -XX:+CrashOnOutOfMemoryError \
+  -XX:+CrashOnOutOfMemoryError \
   -XX:ErrorFile="${LOGS_DIRECTORY}/<%= EZBake::Config[:real_name] %>_err_pid%p.log" \
   -cp "${INSTALL_DIR}/<%= EZBake::Config[:uberjar_name] %>" \
   clojure.main \


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvoxdb & openvox-server. The
packages will be stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archives will be linked at the bottom. It's
always named openvoxerver/openvoxdb-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description

This commit removes any left-over uses of `-XX:OnOutOfMemoryError=kill -9 %p` in favor of the CrashOnOutOfMemoryError option introduced in Java 8. Using both is redundant, and CrashOnOutOfMemoryError is a much gentler way to take the JVM down that allows time for a crash log to be written and some cleanup handlers to run.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
