### PR TITLE
Explicitly check out main branch during backports

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -43,6 +43,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           token: ${{ secrets.OPENVOXBOT_COMMIT_AND_PRS }}
+          ref: main
       - name: Create backport pull requests
         uses: korthout/backport-action@2e830a1d0b8269505846ddd407a70876913ad1f8 # v4.6.0
         with:


### PR DESCRIPTION
#### Pull Request (PR) description

The v7 release of `actions/checkout` introduced a major change where it will refuse to check out repository state that may be mutated by the pull request. This commit explicitly sets `ref: main` on the checkout step of the workflow as `korthout/backport-action` has logic for finding the pull request and cherry-picking commits out of it.


#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
