### PR TITLE
Depend on Java 21+ when building OpenVox 9

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.openvoxproject/lein-ezbake "2.7.10-SNAPSHOT"
+(defproject org.openvoxproject/lein-ezbake "2.8.0-SNAPSHOT"
   :description "A system for building packages for trapperkeeper-based applications"
   :url "https://github.com/openvoxproject/ezbake"
   :license {:name "Apache License 2.0"

--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -209,34 +209,63 @@ if options.output_type == 'rpm'
   fpm_opts << "--rpm-rpmbuild-define '_app_prefix #{options.app_prefix}'"
   fpm_opts << "--rpm-rpmbuild-define '_app_data #{options.app_data}'"
 
-  if options.operating_system == :fedora # all supported fedoras are systemd and provide Java 21
+  if options.operating_system == :fedora
     options.systemd = 1
     options.systemd_el = 1
-    options.java = 'jre-21-headless'
-    options.java_bin = '/usr/lib/jvm/jre-21/bin/java'
-  elsif options.operating_system == :amazon
-    fpm_opts << "--depends tzdata-java"
-    options.java = 'java-17-amazon-corretto-headless'
-    options.systemd = 1
-    options.systemd_el = 1
-  elsif options.operating_system == :el || options.operating_system == :redhatfips
-    if options.os_version <= 7
-      raise "el version #{options.os_version} is no longer supported"
-    elsif (8..9).include?(options.os_version)
-      options.java = 'jre-17-headless'
-      options.java_bin = '/usr/lib/jvm/jre-17/bin/java'
-    elsif options.os_version >= 10
+
+    case options.platform_version
+    when 8
       options.java = 'jre-21-headless'
       options.java_bin = '/usr/lib/jvm/jre-21/bin/java'
-    else
-      fail "Unrecognized el os version #{options.os_version}"
+    when 9
+      options.java = 'jre-25-headless'
+      options.java_bin = '/usr/lib/jvm/jre-25/bin/java'
     end
+  elsif options.operating_system == :amazon
+    fpm_opts << "--depends tzdata-java"
+    options.systemd = 1
     options.systemd_el = 1
+
+    case options.platform_version
+    when 8
+      options.java = 'java-17-amazon-corretto-headless'
+    when 9
+      options.java = 'java-25-amazon-corretto-headless'
+      options.java_bin = '/usr/lib/jvm/java-25-amazon-corretto.x86_64/bin/java'
+    end
+  elsif options.operating_system == :el || options.operating_system == :redhatfips
+    options.systemd_el = 1
+
+    case [options.os_version, options.platform_version]
+    # OpenVox 8.x
+    in [8 | 9, 8]
+      options.java = 'jre-17-headless'
+      options.java_bin = '/usr/lib/jvm/jre-17/bin/java'
+    in [10, 8]
+      options.java = 'jre-21-headless'
+      options.java_bin = '/usr/lib/jvm/jre-21/bin/java'
+    # OpenVox 9.x
+    in [8, 9]
+      options.java = 'jre-21-headless'
+      options.java_bin = '/usr/lib/jvm/jre-21/bin/java'
+    in [9 | 10, 9]
+      options.java = 'jre-25-headless'
+      options.java_bin = '/usr/lib/jvm/jre-25/bin/java'
+    else
+      fail "Unrecognized el os version #{options.os_version} for platform #{options.platform_version}"
+    end
   elsif options.operating_system == :sles
     options.systemd_sles = 1
     options.sles = 1
-    options.java = 'java-17-openjdk-headless'
     options.rpmbuild_wrapper_dir = create_sles_rpmbuild_wrapper
+
+    case options.platform_version
+    when 8
+      options.java = 'java-17-openjdk-headless'
+    when 9
+      options.java = 'java-25-openjdk-headless'
+      options.java_bin = '/usr/lib64/jvm/jre-25/bin/java'
+    end
   end
 
   fpm_opts << "--rpm-rpmbuild-define '_systemd_el #{options.systemd_el}'"
@@ -336,14 +365,20 @@ elsif options.output_type == 'deb'
 
   # figure out correct java dependency
   case options.dist
-  # Bullseye, Bookworm
+  # Bullseye, Bookworm, only supported by OpenVox 8.x
   when 'debian11','debian12'
     options.java = 'openjdk-17-jre-headless'
     options.java_bin = '/usr/lib/jvm/java-17-openjdk-amd64/bin/java'
-  # Trixie, Focal Fossa, Jammy Jellyfish, Noble Numbat, Plucky Puffin, Questing Quokka, Resolute Raccoon
-  when 'debian13', 'ubuntu20.04', 'ubuntu22.04', 'ubuntu24.04', 'ubuntu25.04', 'ubuntu25.10', 'ubuntu26.04'
-    options.java = 'openjdk-21-jre-headless'
-    options.java_bin = '/usr/lib/jvm/java-21-openjdk-amd64/bin/java'
+  # Trixie, Jammy Jellyfish, Noble Numbat, Plucky Puffin, Questing Quokka, Resolute Raccoon
+  when 'debian13', 'ubuntu22.04', 'ubuntu24.04', 'ubuntu25.04', 'ubuntu25.10', 'ubuntu26.04'
+    case options.platform_version
+    when 8
+      options.java = 'openjdk-21-jre-headless'
+      options.java_bin = '/usr/lib/jvm/java-21-openjdk-amd64/bin/java'
+    when 9
+      options.java = 'openjdk-25-jre-headless'
+      options.java_bin = '/usr/lib/jvm/java-25-openjdk-amd64/bin/java'
+    end
   else
     fail "no matching OS data found for #{options.dist}"
   end


### PR DESCRIPTION


<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

- The CI will build rpm and deb packages for openvoxdb & openvox-server. The
packages will be stored in a zip archive and uploaded as GitHub artifacts.
In the PR, go to Checks -> main. The archives will be linked at the bottom. It's
always named openvoxerver/openvoxdb-$(git describe). The artifacts are available for 24
hours.

-->

#### Pull Request (PR) description

OpenVox 9 requires Java 21 or newer. This is a hard requirement, imposed by JRuby 10 dropping compatibility with anything older.

This commit adds a bunch of `case` statements to the logic in `fpm.rb` that pick the Java version depending on the `--platform-version` passed during build time. This platform version is set in project.clj in the openvox-server and openvoxdb projects, and has a value of 8 on the 8.x branches and 9 on the main branches.

This change retains the mix of Java 17 and Java 21 used by OpenVox 8.x and moves OpenVox 9.x builds almost entirely to Java 25, with EL 8 being the lone straggler on Java 21.

These changes were back-ported from OpenVox/ezbake#106, OpenVox/ezbake#107, and OpenVox/ezbake#108.
#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
