### PR TITLE
Handle pre-release versions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.openvoxproject/lein-ezbake "2.8.1-SNAPSHOT"
+(defproject org.openvoxproject/lein-ezbake "2.9.0-SNAPSHOT"
   :description "A system for building packages for trapperkeeper-based applications"
   :url "https://github.com/openvoxproject/ezbake"
   :license {:name "Apache License 2.0"

--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -686,9 +686,9 @@ Additional uberjar dependencies:
   [lein-version]
   {:pre [(string? lein-version)]
    :post [(string? %)]}
-  (if (.endsWith lein-version "-SNAPSHOT")
-    (format "%s"
-            (str/replace lein-version #"-SNAPSHOT|-" { "-SNAPSHOT" "" "-" "."}))
+  (condp re-find lein-version
+    #"\A\d+\.\d+\.\d+-(?:alpha|beta|rc)\d+" (str/replace lein-version "-" "~")
+    #"-SNAPSHOT$" (str/replace lein-version #"-SNAPSHOT|-" { "-SNAPSHOT" "" "-" "."})
     lein-version))
 
 (defn generate-package-release-from-version


### PR DESCRIPTION
#### Pull Request (PR) description

Handle pre-release versions

This commit updates the logic in `fpm.rb` that handles the `--package-version`
flag. If the flag matches a semver.org pre-release with "alpha", "beta"
or "rc" as the pre-release identifier, then the "-" in the version
string is substituted for "~". That is, a version like `9.0.0-beta1` becomes
the following version in package metadata: `9.0.0~beta1`

This is done because the `dpkg` and `rpm` package managers treat `~`
specially and sort any version strings containing it before all other
strings. This changes allows a `9.0.0~alpha1` package to upgrade to
`9.0.0~beta1`, and then to `9.0.0~rc0`, and finally to `9.0.0`.

See: https://semver.org
See: https://manpages.debian.org/bookworm/dpkg-dev/deb-version.7.en.html#Sorting_al
gorithm
See: https://rpm.org/docs/6.0.x/man/rpm-version.7#Comparing



#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
