### PR TITLE
Anchor pre-release regex on end of string

### DIFF
--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -687,7 +687,7 @@ Additional uberjar dependencies:
   {:pre [(string? lein-version)]
    :post [(string? %)]}
   (condp re-find lein-version
-    #"\A\d+\.\d+\.\d+-(?:alpha|beta|rc)\d+" (str/replace lein-version "-" "~")
+    #"\A\d+\.\d+\.\d+-(?:alpha|beta|rc)\d+\z" (str/replace lein-version "-" "~")
     #"-SNAPSHOT$" (str/replace lein-version #"-SNAPSHOT|-" { "-SNAPSHOT" "" "-" "."})
     lein-version))
 

--- a/test/unit/puppetlabs/ezbake/core_test.clj
+++ b/test/unit/puppetlabs/ezbake/core_test.clj
@@ -93,3 +93,23 @@
               (core/make-template-map dummy-project "dummy-build-target"
                                       [] [] [] [] [] {} [] [] []
                                       (core/get-timestamp-string))))))))
+
+(deftest generate-package-version-from-version-behavior
+  (testing "8+ and 9+ snapshot versions are normalized for packaging"
+    (is (= "8.0.0" (core/generate-package-version-from-version "8.0.0-SNAPSHOT")))
+    (is (= "9.0.0" (core/generate-package-version-from-version "9.0.0-SNAPSHOT"))))
+  (testing "snapshot qualifiers preserve semantic segments by converting hyphens to dots"
+    (is (= "8.1.0.alpha" (core/generate-package-version-from-version "8.1.0-alpha-SNAPSHOT")))
+    (is (= "9.2.0.rc1" (core/generate-package-version-from-version "9.2.0-rc1-SNAPSHOT"))))
+  (testing "beta1 snapshot variants are normalized"
+    (is (= "8.3.0.beta1" (core/generate-package-version-from-version "8.3.0-beta1-SNAPSHOT")))
+    (is (= "9.4.1.beta1" (core/generate-package-version-from-version "9.4.1-beta1-SNAPSHOT")))
+    (is (= "9.4.1.beta1.hotfix" (core/generate-package-version-from-version "9.4.1-beta1-hotfix-SNAPSHOT"))))
+  (testing "non-snapshot versions are unchanged"
+    (is (= "8.0.0" (core/generate-package-version-from-version "8.0.0")))
+    (is (= "9.1.2+build7" (core/generate-package-version-from-version "9.1.2+build7")))
+    (is (= "10.0.0-RC1" (core/generate-package-version-from-version "10.0.0-RC1")))
+    (is (= "9.4.1-beta1" (core/generate-package-version-from-version "9.4.1-beta1"))))
+  (testing "input contract enforces string argument"
+    (is (thrown? AssertionError
+                 (core/generate-package-version-from-version 9)))))

--- a/test/unit/puppetlabs/ezbake/core_test.clj
+++ b/test/unit/puppetlabs/ezbake/core_test.clj
@@ -105,11 +105,13 @@
     (is (= "8.3.0.beta1" (core/generate-package-version-from-version "8.3.0-beta1-SNAPSHOT")))
     (is (= "9.4.1.beta1" (core/generate-package-version-from-version "9.4.1-beta1-SNAPSHOT")))
     (is (= "9.4.1.beta1.hotfix" (core/generate-package-version-from-version "9.4.1-beta1-hotfix-SNAPSHOT"))))
+  (testing "tagged pre-release versions are munged to include a tilde"
+    (is (= "8.0.0~alpha2" (core/generate-package-version-from-version "8.0.0-alpha2")))
+    (is (= "9.4.1~beta1" (core/generate-package-version-from-version "9.4.1-beta1")))
+    (is (= "10.0.0~rc0" (core/generate-package-version-from-version "10.0.0-rc0"))))
   (testing "non-snapshot versions are unchanged"
     (is (= "8.0.0" (core/generate-package-version-from-version "8.0.0")))
-    (is (= "9.1.2+build7" (core/generate-package-version-from-version "9.1.2+build7")))
-    (is (= "10.0.0-RC1" (core/generate-package-version-from-version "10.0.0-RC1")))
-    (is (= "9.4.1-beta1" (core/generate-package-version-from-version "9.4.1-beta1"))))
+    (is (= "9.1.2+build7" (core/generate-package-version-from-version "9.1.2+build7"))))
   (testing "input contract enforces string argument"
     (is (thrown? AssertionError
                  (core/generate-package-version-from-version 9)))))


### PR DESCRIPTION
#### Pull Request (PR) description

This commit makes a small change to the regex for determining when to
build a pre-release to anchor on the end of the string. This means that
only full rlease versions, such as `9.0.0-beta1`, will be matched and not
releases between tags, like: `9.0.0-beta1-SNAPSHOT`

Proper test coverage for version munging is also added.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
