### PR TITLE
[Forward-port main]: Handle pre-release versions

### DIFF
--- a/src/puppetlabs/ezbake/core.clj
+++ b/src/puppetlabs/ezbake/core.clj
@@ -686,9 +686,9 @@ Additional uberjar dependencies:
   [lein-version]
   {:pre [(string? lein-version)]
    :post [(string? %)]}
-  (if (.endsWith lein-version "-SNAPSHOT")
-    (format "%s"
-            (str/replace lein-version #"-SNAPSHOT|-" { "-SNAPSHOT" "" "-" "."}))
+  (condp re-find lein-version
+    #"\A\d+\.\d+\.\d+-(?:alpha|beta|rc)\d+\z" (str/replace lein-version "-" "~")
+    #"-SNAPSHOT$" (str/replace lein-version #"-SNAPSHOT|-" { "-SNAPSHOT" "" "-" "."})
     lein-version))
 
 (defn generate-package-release-from-version

--- a/test/unit/puppetlabs/ezbake/core_test.clj
+++ b/test/unit/puppetlabs/ezbake/core_test.clj
@@ -105,11 +105,13 @@
     (is (= "8.3.0.beta1" (core/generate-package-version-from-version "8.3.0-beta1-SNAPSHOT")))
     (is (= "9.4.1.beta1" (core/generate-package-version-from-version "9.4.1-beta1-SNAPSHOT")))
     (is (= "9.4.1.beta1.hotfix" (core/generate-package-version-from-version "9.4.1-beta1-hotfix-SNAPSHOT"))))
+  (testing "tagged pre-release versions are munged to include a tilde"
+    (is (= "8.0.0~alpha2" (core/generate-package-version-from-version "8.0.0-alpha2")))
+    (is (= "9.4.1~beta1" (core/generate-package-version-from-version "9.4.1-beta1")))
+    (is (= "10.0.0~rc0" (core/generate-package-version-from-version "10.0.0-rc0"))))
   (testing "non-snapshot versions are unchanged"
     (is (= "8.0.0" (core/generate-package-version-from-version "8.0.0")))
-    (is (= "9.1.2+build7" (core/generate-package-version-from-version "9.1.2+build7")))
-    (is (= "10.0.0-RC1" (core/generate-package-version-from-version "10.0.0-RC1")))
-    (is (= "9.4.1-beta1" (core/generate-package-version-from-version "9.4.1-beta1"))))
+    (is (= "9.1.2+build7" (core/generate-package-version-from-version "9.1.2+build7"))))
   (testing "input contract enforces string argument"
     (is (thrown? AssertionError
                  (core/generate-package-version-from-version 9)))))


### PR DESCRIPTION
#### Pull Request (PR) description

This commit updates the logic that populates the `package-version` variable. If the value matches a semver.org pre-release with "alpha", "beta" or "rc" as the pre-release identifier, then the "-" in the version string is substituted for "~". That is, a version like `9.0.0-beta1` becomes the following package-version in EZbake output: `9.0.0~beta1`

This is done because the `dpkg` and `rpm` package managers treat `~` specially and sort any version strings containing it before all other strings. This changes allows a `9.0.0~alpha1` package to upgrade to `9.0.0~beta1`, and then to `9.0.0~rc0`, and finally to `9.0.0`.

See: https://semver.org
See: https://manpages.debian.org/bookworm/dpkg-dev/deb-version.7.en.html#Sorting_algorithm
See: https://rpm.org/docs/6.0.x/man/rpm-version.7#Comparing

This is a forward-port of #127 and #131 from the `2.x` branch.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
