### PR TITLE
feat: run foreground as current user, support arbitrary UIDs

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/cli/foreground.erb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/cli/foreground.erb
@@ -25,14 +25,11 @@ COMMAND="${JAVA_BIN} ${JAVA_ARGS} ${LOG_APPENDER} \
          ${TK_ARGS} \
          ${@}"
 
-pushd "${INSTALL_DIR}" &> /dev/null
-if [ "$EUID" = "0" ] && command -v runuser &> /dev/null; then
-  runuser "${USER}" -s /bin/bash -c "$COMMAND"
-elif [ "$EUID" = "$(id -u ${USER})" ]; then
-  /bin/bash -c "$COMMAND"
-elif command -v sudo &> /dev/null; then
-  sudo -H -u "${USER}" $COMMAND
-else
-  su "${USER}" -s /bin/bash -c "$COMMAND"
+cd "${INSTALL_DIR}"
+if [ "$EUID" = "0" ] && [ -n "${USER}" ] && command -v runuser &> /dev/null; then
+  # started as root: drop to the service user
+  exec runuser "${USER}" -s /bin/bash -c "$COMMAND"
 fi
-popd &> /dev/null
+# containers set the runtime UID before this script runs (USER directive,
+# --user, runAsUser), so run as the current user - whatever UID that is
+exec /bin/bash -c "$COMMAND"


### PR DESCRIPTION
#### Pull Request (PR) description

Currently the `foreground` script is used to switch to a service user when executed as root  (among other things). It also lets you keep the user that you executed it as in [this check](https://github.com/OpenVoxProject/ezbake/blob/b7dde28be9be75eb904c43985c8f24982c5cc478/resources/puppetlabs/lein-ezbake/template/global/ext/cli/foreground.erb#L31) (added in [this](https://github.com/puppetlabs/ezbake/pull/588) PR). 

That check resolves `id -u ${USER}` to check if it matches the executing UID, but when running containers with arbitrary UIDs the runtime user usually does not have a username. Currently the server container is using a [sed command](https://github.com/OpenVoxProject/container-openvoxserver/blob/fa74f20b29459cb0015becf8451f779375d7c218/openvoxserver/prep_release_container.sh#L175-L176) to clear the USER variable, as `id -u` without an argument resolves in the current user's ID. This PR would remove the need for the USER variable when no user switch is required (or possible). 

If running as root and USER is set, switch to user. If not, just run. Before it would also effectively check if `USER` matches the executing user's name (by comparing the UID that belongs to the username). This and the su/sudo branches do not make sense anymore if the script is intended as container only, which [it is](https://github.com/OpenVoxProject/ezbake/blob/b7dde28be9be75eb904c43985c8f24982c5cc478/resources/puppetlabs/lein-ezbake/template/global/ext/cli/foreground.erb#L3).


Behaviour changes: a non-root UID that doesn't match USER now starts the service as that UID instead of failing in the sudo/su branches, and root with an empty USER now runs as root instead of failing with `runuser: user does not exist`.

PS: the `runuser: user does not exist` error can be replicated using: 
```bash
docker run --rm --user 0 --entrypoint /bin/bash ghcr.io/openvoxproject/openvoxserver:latest -c '
  grep -n "^ *USER=" /etc/default/puppetserver
  /opt/puppetlabs/server/bin/puppetserver foreground
  echo "exit code: $?"'
```
`runuser: user  does not exist or the user entry does not contain all the required fields`


EDIT:  The reason I swapped to cd was that popd was unreachable anyways, exec replaces the shell with the JVM. `popd/pushd` does not make sense here.