### PR TITLE
Depend on Java 21 for RedHat FIPS

### DIFF
--- a/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
+++ b/resources/puppetlabs/lein-ezbake/template/global/ext/fpm.rb
@@ -254,7 +254,13 @@ if options.output_type == 'rpm'
     options.java_bin = '/usr/lib/jvm/java-25-amazon-corretto.x86_64/bin/java'
     options.systemd_el = 1
   elsif options.operating_system == :el || options.operating_system == :redhatfips
-    if options.os_version == 8
+    # All RedHat FIPS versions must use Java 21 as BouncyCastle is not
+    # FIPS certified for any newer JVM versions:
+    #
+    # > The 2.1.0 release, BC-FJA 2.1.0 (Certificate #4943) , is certified for
+    # > use on Java 8, Java 11, Java 17, and Java 21.
+    # https://www.bouncycastle.org/download/bouncy-castle-java-fips/
+    if options.os_version == 8 || options.operating_system == :redhatfips
       options.java = 'jre-21-headless'
       options.java_bin = '/usr/lib/jvm/jre-21/bin/java'
     elsif options.os_version >= 9


### PR DESCRIPTION
#### Pull Request (PR) description

JRuby 10 requires Java 21 or newer, but the newest version of Java that BouncyCastle libraries are certified for use with is 21. This commit updates all RedHat FIPS platforms to depend on Java 21 --- effectively moving RedHat FIPS 9 back from Java 25 to 21.

See: https://www.bouncycastle.org/download/bouncy-castle-java-fips/

#### This Pull Request (PR) fixes the following issues

N/A
